### PR TITLE
Add unit tests and testing configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# Imou Control
+
+Repositório de desenvolvimento para a integração Imou Control.
+
+## Testes
+
+Para executar a suíte de testes:
+
+```bash
+tox
+```
+
+Ou diretamente com pytest:
+
+```bash
+pytest
+```

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,56 @@
+import sys
+import types
+import importlib.util
+import pathlib
+import pytest
+
+PACKAGE_NAME = "custom_components.imou_control"
+PACKAGE_PATH = pathlib.Path(__file__).resolve().parent.parent / "custom_components" / "imou_control"
+
+
+def _ensure_package() -> types.ModuleType:
+    if "custom_components" not in sys.modules:
+        sys.modules["custom_components"] = types.ModuleType("custom_components")
+    pkg = sys.modules.get(PACKAGE_NAME)
+    if pkg is None:
+        pkg = types.ModuleType(PACKAGE_NAME)
+        pkg.__path__ = [str(PACKAGE_PATH)]
+        sys.modules[PACKAGE_NAME] = pkg
+        # load const to expose endpoints
+        spec_const = importlib.util.spec_from_file_location(
+            f"{PACKAGE_NAME}.const", PACKAGE_PATH / "const.py"
+        )
+        mod_const = importlib.util.module_from_spec(spec_const)
+        sys.modules[f"{PACKAGE_NAME}.const"] = mod_const
+        spec_const.loader.exec_module(mod_const)
+        pkg.TOKEN_ENDPOINT = mod_const.TOKEN_ENDPOINT
+        pkg.PTZ_LOCATION_ENDPOINT = mod_const.PTZ_LOCATION_ENDPOINT
+        # load utils helper
+        spec_utils = importlib.util.spec_from_file_location(
+            f"{PACKAGE_NAME}.utils", PACKAGE_PATH / "utils.py"
+        )
+        mod_utils = importlib.util.module_from_spec(spec_utils)
+        sys.modules[f"{PACKAGE_NAME}.utils"] = mod_utils
+        spec_utils.loader.exec_module(mod_utils)
+    return pkg
+
+
+def import_imou_module(name: str):
+    _ensure_package()
+    spec = importlib.util.spec_from_file_location(
+        f"{PACKAGE_NAME}.{name}", PACKAGE_PATH / f"{name}.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[f"{PACKAGE_NAME}.{name}"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def token_module():
+    return import_imou_module("token_manager")
+
+
+@pytest.fixture
+def api_module():
+    return import_imou_module("api")

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -1,0 +1,51 @@
+import pytest
+
+
+class DummyResp:
+    def __init__(self, data):
+        self._data = data
+        self.content = b"1"
+
+    def json(self):
+        return self._data
+
+    def raise_for_status(self):
+        pass
+
+
+def test_retry_on_token_error(monkeypatch, api_module):
+    calls = []
+
+    def fake_post(url, json, timeout):
+        calls.append(json["params"].get("token"))
+        if len(calls) == 1:
+            data = {"result": {"code": "TK1002", "msg": "bad"}}
+        else:
+            data = {"result": {"code": "0", "data": {}}}
+        return DummyResp(data)
+
+    monkeypatch.setattr(api_module.requests, "post", fake_post)
+    token = "t1"
+
+    def get_token():
+        return token
+
+    def refresh_token():
+        nonlocal token
+        token = "t2"
+        return token
+
+    api = api_module.ApiClient("id", "sec", "http://host", get_token, refresh_token)
+    assert api.set_position("dev", 0.1, 0.2, 0.3)
+    assert calls == ["t1", "t2"]
+
+
+def test_failure_raises(monkeypatch, api_module):
+    def fake_post(url, json, timeout):
+        data = {"result": {"code": "123", "msg": "fail"}}
+        return DummyResp(data)
+
+    monkeypatch.setattr(api_module.requests, "post", fake_post)
+    api = api_module.ApiClient("id", "sec", "http://host", lambda: "tok", lambda: "tok2")
+    with pytest.raises(RuntimeError):
+        api.set_position("dev", 0, 0, 0)

--- a/tests/test_token_manager.py
+++ b/tests/test_token_manager.py
@@ -1,0 +1,48 @@
+import pytest
+
+
+class DummyResp:
+    def __init__(self, token: str):
+        self._token = token
+        self.content = b"1"
+
+    def json(self):
+        return {
+            "result": {
+                "code": "0",
+                "data": {"accessToken": self._token, "expireTime": 60},
+            }
+        }
+
+    def raise_for_status(self):
+        pass
+
+
+def test_get_token_caches(monkeypatch, token_module):
+    calls = []
+
+    def fake_post(url, json, timeout):
+        calls.append(1)
+        return DummyResp("abc")
+
+    monkeypatch.setattr(token_module.requests, "post", fake_post)
+    tm = token_module.TokenManager("id", "secret", "http://host")
+    t1 = tm.get_token()
+    t2 = tm.get_token()
+    assert t1 == t2 == "abc"
+    assert len(calls) == 1
+
+
+def test_refresh_and_invalidate(monkeypatch, token_module):
+    tokens = ["first", "second", "third"]
+
+    def fake_post(url, json, timeout):
+        return DummyResp(tokens.pop(0))
+
+    monkeypatch.setattr(token_module.requests, "post", fake_post)
+    tm = token_module.TokenManager("id", "secret", "http://host")
+    assert tm.get_token() == "first"
+    assert tm.refresh_token() == "second"
+    tm.invalidate()
+    assert tm.get_token() == "third"
+    assert tokens == []

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,8 @@
+[tox]
+envlist = py
+
+[testenv]
+deps =
+    pytest
+    requests
+commands = pytest


### PR DESCRIPTION
## Summary
- add token manager and API client unit tests
- configure tox/pytest and document usage

## Testing
- `tox -q`

------
https://chatgpt.com/codex/tasks/task_e_68c6f19f90208325846e57578d55b0e2