### PR TITLE
Use aiohttp for async network operations

### DIFF
--- a/custom_components/imou_control/__init__.py
+++ b/custom_components/imou_control/__init__.py
@@ -31,7 +31,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         v = float(call.data["v"])
         z = float(call.data.get("z", 0.0))
         try:
-            ok = await hass.async_add_executor_job(api.set_position, device_id, h, v, z)
+            ok = await api.set_position(device_id, h, v, z)
             if not ok:
                 _LOGGER.warning("set_position retornou False para %s", device_id)
         except Exception as e:

--- a/custom_components/imou_control/manifest.json
+++ b/custom_components/imou_control/manifest.json
@@ -3,7 +3,7 @@
   "name": "Imou Control",
   "version": "0.0.3",
   "config_flow": true,
-  "requirements": ["requests>=2.28.0"],
+  "requirements": ["aiohttp>=3.8.0"],
   "codeowners": ["@<seu-usuario-github>"],
   "documentation": "https://github.com/<user>/<repo>#readme",
   "issue_tracker": "https://github.com/<user>/<repo>/issues",


### PR DESCRIPTION
## Summary
- replace `requests` with `aiohttp` and make API calls async
- make token management async
- call async API methods directly without executor and update manifest

## Testing
- `python -m py_compile custom_components/imou_control/*.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6f19da1ec8325b4d1528e78c1d31a