### PR TITLE
Add select platform integration and setup forwarding

### DIFF
--- a/custom_components/imou_control/__init__.py
+++ b/custom_components/imou_control/__init__.py
@@ -11,6 +11,8 @@ from .api import ApiClient
 
 _LOGGER = logging.getLogger(__name__)
 
+PLATFORMS = ["select"]
+
 async def async_setup(hass: HomeAssistant, config: dict) -> bool:
     return True
 
@@ -47,9 +49,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             vol.Optional("z", default=0.0): vol.Coerce(float),
         })
     )
-
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    hass.data[DOMAIN].pop(entry.entry_id, None)
-    return True
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    if unload_ok:
+        hass.data[DOMAIN].pop(entry.entry_id, None)
+    return unload_ok

--- a/custom_components/imou_control/manifest.json
+++ b/custom_components/imou_control/manifest.json
@@ -9,5 +9,5 @@
   "issue_tracker": "https://github.com/<user>/<repo>/issues",
   "iot_class": "cloud_polling",
   "loggers": ["custom_components.imou_control"],
-  "platforms": []
+  "platforms": ["select"]
 }


### PR DESCRIPTION
## Summary
- expose select platform in manifest
- forward config entry setup and unload select platform

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c6f19bda5883258ce4c35099c1cb6b