### PR TITLE
Support dynamic device registration and updates

### DIFF
--- a/custom_components/imou_control/__init__.py
+++ b/custom_components/imou_control/__init__.py
@@ -4,8 +4,9 @@ import voluptuous as vol
 import homeassistant.helpers.config_validation as cv
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.helpers.dispatcher import async_dispatcher_send
 
-from .const import DOMAIN, CONF_APP_ID, CONF_APP_SECRET, CONF_URL_BASE
+from .const import DOMAIN, CONF_APP_ID, CONF_APP_SECRET, CONF_URL_BASE, SIGNAL_NEW_DEVICE
 from .token_manager import TokenManager
 from .api import ApiClient
 
@@ -21,11 +22,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     app_secret = entry.data[CONF_APP_SECRET]
     url_base   = entry.data[CONF_URL_BASE]
 
-    tm  = TokenManager(app_id, app_secret, url_base)
-    api = ApiClient(app_id, app_secret, url_base, tm.get_token, tm.refresh_token)
+    tm = TokenManager(app_id, app_secret, url_base)
+    api = ApiClient(app_id, app_secret, url_base, tm.async_get_token, tm.async_refresh_token)
 
     hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN][entry.entry_id] = {"tm": tm, "api": api}
+    hass.data[DOMAIN][entry.entry_id] = {"tm": tm, "api": api, "devices": []}
+
+    async def async_add_device(device: dict) -> None:
+        """Add a discovered/configured device and notify listeners."""
+        devices = hass.data[DOMAIN][entry.entry_id]["devices"]
+        devices.append(device)
+        async_dispatcher_send(hass, SIGNAL_NEW_DEVICE, entry.entry_id, device)
+
+    hass.data[DOMAIN][entry.entry_id]["add_device"] = async_add_device
 
     async def srv_set_position(call: ServiceCall):
         device_id = call.data["device_id"]
@@ -33,7 +42,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         v = float(call.data["v"])
         z = float(call.data.get("z", 0.0))
         try:
-            ok = await api.set_position(device_id, h, v, z)
+            ok = await api.async_set_position(device_id, h, v, z)
             if not ok:
                 _LOGGER.warning("set_position retornou False para %s", device_id)
         except Exception as e:
@@ -41,13 +50,39 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             raise
 
     hass.services.async_register(
-        DOMAIN, "set_position", srv_set_position,
-        schema=vol.Schema({
-            vol.Required("device_id"): cv.string,
-            vol.Required("h"): vol.Coerce(float),
-            vol.Required("v"): vol.Coerce(float),
-            vol.Optional("z", default=0.0): vol.Coerce(float),
-        })
+        DOMAIN,
+        "set_position",
+        srv_set_position,
+        schema=vol.Schema(
+            {
+                vol.Required("device_id"): cv.string,
+                vol.Required("h"): vol.Coerce(float),
+                vol.Required("v"): vol.Coerce(float),
+                vol.Optional("z", default=0.0): vol.Coerce(float),
+            }
+        ),
+    )
+
+    async def srv_register_device(call: ServiceCall):
+        """Register a device at runtime."""
+        device = {
+            "device_id": call.data["device_id"],
+            "name": call.data.get("name"),
+            "model": call.data.get("model"),
+        }
+        await async_add_device(device)
+
+    hass.services.async_register(
+        DOMAIN,
+        "register_device",
+        srv_register_device,
+        schema=vol.Schema(
+            {
+                vol.Required("device_id"): cv.string,
+                vol.Optional("name"): cv.string,
+                vol.Optional("model"): cv.string,
+            }
+        ),
     )
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
@@ -55,5 +90,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
-        hass.data[DOMAIN].pop(entry.entry_id, None)
+        entry_data = hass.data[DOMAIN].pop(entry.entry_id, {})
+        unsub = entry_data.get("unsub_dispatcher")
+        if unsub:
+            unsub()
     return unload_ok

--- a/custom_components/imou_control/const.py
+++ b/custom_components/imou_control/const.py
@@ -8,3 +8,6 @@ CONF_URL_BASE = "url_base"
 # Endpoints padrão da Open API (relativos ao url_base)
 TOKEN_ENDPOINT = "/openapi/accessToken"
 PTZ_LOCATION_ENDPOINT = "/openapi/controlLocationPTZ"
+
+# Sinal usado para notificar novas câmeras descobertas/configuradas
+SIGNAL_NEW_DEVICE = "imou_control_new_device"

--- a/custom_components/imou_control/select.py
+++ b/custom_components/imou_control/select.py
@@ -4,7 +4,8 @@ from typing import List
 from homeassistant.components.select import SelectEntity
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.core import callback
-from . import DOMAIN
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from .const import DOMAIN, SIGNAL_NEW_DEVICE
 
 async def async_setup_entry(hass, entry, async_add_entities):
     data = hass.data[DOMAIN][entry.entry_id]
@@ -14,6 +15,16 @@ async def async_setup_entry(hass, entry, async_add_entities):
     for d in devices:
         entities.append(ImouCameraPresetSelect(entry, d))
     async_add_entities(entities, True)
+
+    @callback
+    def _async_new_device(entry_id, device):
+        if entry_id != entry.entry_id:
+            return
+        async_add_entities([ImouCameraPresetSelect(entry, device)])
+
+    data["unsub_dispatcher"] = async_dispatcher_connect(
+        hass, SIGNAL_NEW_DEVICE, _async_new_device
+    )
 
 class ImouCameraPresetSelect(SelectEntity):
     _attr_icon = "mdi:format-list-numbered"

--- a/custom_components/imou_control/services.yaml
+++ b/custom_components/imou_control/services.yaml
@@ -14,3 +14,17 @@ set_position:
     z:
       description: Zoom (opcional; padrão 0)
       example: 0
+
+register_device:
+  name: Registrar dispositivo
+  description: Adiciona manualmente um dispositivo à integração.
+  fields:
+    device_id:
+      description: Device ID da câmera na Imou
+      example: 5250FACPBV99ADE
+    name:
+      description: Nome amigável (opcional)
+      example: Sala
+    model:
+      description: Modelo da câmera (opcional)
+      example: IPC-A22EP


### PR DESCRIPTION
## Summary
- Initialize per-entry device lists and expose a `register_device` service
- Notify platforms of new devices and let select entities register dynamically
- Add signal constant and document new service

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c708f87d3c8325ab9f9a86f093e83a