### PR TITLE
Handle empty API responses

### DIFF
--- a/custom_components/imou_control/api.py
+++ b/custom_components/imou_control/api.py
@@ -58,9 +58,10 @@ class ApiClient:
         async with aiohttp.ClientSession(timeout=timeout) as session:
             async with session.post(self._url(path), json=payload) as resp:
                 resp.raise_for_status()
-                if resp.content_length:
+                try:
                     return await resp.json(content_type=None)
-                return {}
+                except (aiohttp.ContentTypeError, aiohttp.ClientPayloadError, ValueError):
+                    return {}
 
     async def _call_with_retry(
         self,

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -2,50 +2,107 @@ import pytest
 
 
 class DummyResp:
-    def __init__(self, data):
+    def __init__(self, data=None):
         self._data = data
-        self.content = b"1"
+        self.content_length = None if data is None else 1
 
-    def json(self):
+    async def json(self, content_type=None):
+        if self._data is None:
+            raise ValueError
         return self._data
 
     def raise_for_status(self):
         pass
 
+    async def __aenter__(self):
+        return self
 
-def test_retry_on_token_error(monkeypatch, api_module):
-    calls = []
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
 
-    def fake_post(url, json, timeout):
-        calls.append(json["params"].get("token"))
-        if len(calls) == 1:
-            data = {"result": {"code": "TK1002", "msg": "bad"}}
-        else:
-            data = {"result": {"code": "0", "data": {}}}
+
+class DummySession:
+    def __init__(self, responses, calls=None):
+        self._responses = responses
+        self.calls = calls
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    def post(self, url, json):
+        if self.calls is not None:
+            self.calls.append(json["params"].get("token"))
+        data = self._responses.pop(0)
         return DummyResp(data)
 
-    monkeypatch.setattr(api_module.requests, "post", fake_post)
+
+@pytest.mark.asyncio
+async def test_retry_on_token_error(monkeypatch, api_module):
+    responses = [
+        {"result": {"code": "TK1002", "msg": "bad"}},
+        {"result": {"code": "0", "data": {}}},
+    ]
+    calls = []
+
+    monkeypatch.setattr(
+        api_module.aiohttp,
+        "ClientSession",
+        lambda timeout: DummySession(responses, calls),
+    )
+
     token = "t1"
 
-    def get_token():
+    async def get_token():
         return token
 
-    def refresh_token():
+    async def refresh_token():
         nonlocal token
         token = "t2"
         return token
 
     api = api_module.ApiClient("id", "sec", "http://host", get_token, refresh_token)
-    assert api.set_position("dev", 0.1, 0.2, 0.3)
+    assert await api.set_position("dev", 0.1, 0.2, 0.3)
     assert calls == ["t1", "t2"]
 
 
-def test_failure_raises(monkeypatch, api_module):
-    def fake_post(url, json, timeout):
-        data = {"result": {"code": "123", "msg": "fail"}}
-        return DummyResp(data)
+@pytest.mark.asyncio
+async def test_failure_raises(monkeypatch, api_module):
+    responses = [{"result": {"code": "123", "msg": "fail"}}]
 
-    monkeypatch.setattr(api_module.requests, "post", fake_post)
-    api = api_module.ApiClient("id", "sec", "http://host", lambda: "tok", lambda: "tok2")
+    monkeypatch.setattr(
+        api_module.aiohttp,
+        "ClientSession",
+        lambda timeout: DummySession(responses),
+    )
+
+    async def get_token():
+        return "tok"
+
+    async def refresh_token():
+        return "tok2"
+
+    api = api_module.ApiClient("id", "sec", "http://host", get_token, refresh_token)
     with pytest.raises(RuntimeError):
-        api.set_position("dev", 0, 0, 0)
+        await api.set_position("dev", 0, 0, 0)
+
+
+@pytest.mark.asyncio
+async def test_empty_body_returns_empty_dict(monkeypatch, api_module):
+    responses = [None]
+
+    monkeypatch.setattr(
+        api_module.aiohttp,
+        "ClientSession",
+        lambda timeout: DummySession(responses),
+    )
+
+    async def get_token():
+        return "tok"
+
+    api = api_module.ApiClient("id", "sec", "http://host", get_token)
+    data = await api._do_call("/x", {}, include_token=False)
+    assert data == {}
+

--- a/tests/test_token_manager.py
+++ b/tests/test_token_manager.py
@@ -4,9 +4,9 @@ import pytest
 class DummyResp:
     def __init__(self, token: str):
         self._token = token
-        self.content = b"1"
+        self.content_length = 1
 
-    def json(self):
+    async def json(self, content_type=None):
         return {
             "result": {
                 "code": "0",
@@ -17,32 +17,59 @@ class DummyResp:
     def raise_for_status(self):
         pass
 
+    async def __aenter__(self):
+        return self
 
-def test_get_token_caches(monkeypatch, token_module):
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class DummySession:
+    def __init__(self, tokens, calls=None):
+        self._tokens = tokens
+        self.calls = calls
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    def post(self, url, json):
+        token = self._tokens.pop(0)
+        if self.calls is not None:
+            self.calls.append(1)
+        return DummyResp(token)
+
+
+@pytest.mark.asyncio
+async def test_get_token_caches(monkeypatch, token_module):
     calls = []
+    monkeypatch.setattr(
+        token_module.aiohttp,
+        "ClientSession",
+        lambda timeout: DummySession(["abc"], calls),
+    )
 
-    def fake_post(url, json, timeout):
-        calls.append(1)
-        return DummyResp("abc")
-
-    monkeypatch.setattr(token_module.requests, "post", fake_post)
     tm = token_module.TokenManager("id", "secret", "http://host")
-    t1 = tm.get_token()
-    t2 = tm.get_token()
+    t1 = await tm.get_token()
+    t2 = await tm.get_token()
     assert t1 == t2 == "abc"
     assert len(calls) == 1
 
 
-def test_refresh_and_invalidate(monkeypatch, token_module):
+@pytest.mark.asyncio
+async def test_refresh_and_invalidate(monkeypatch, token_module):
     tokens = ["first", "second", "third"]
 
-    def fake_post(url, json, timeout):
-        return DummyResp(tokens.pop(0))
+    monkeypatch.setattr(
+        token_module.aiohttp,
+        "ClientSession",
+        lambda timeout: DummySession(tokens),
+    )
 
-    monkeypatch.setattr(token_module.requests, "post", fake_post)
     tm = token_module.TokenManager("id", "secret", "http://host")
-    assert tm.get_token() == "first"
-    assert tm.refresh_token() == "second"
+    assert await tm.get_token() == "first"
+    assert await tm.refresh_token() == "second"
     tm.invalidate()
-    assert tm.get_token() == "third"
-    assert tokens == []
+    assert await tm.get_token() == "third"

--- a/tox.ini
+++ b/tox.ini
@@ -4,5 +4,6 @@ envlist = py
 [testenv]
 deps =
     pytest
-    requests
+    pytest-asyncio
+    aiohttp
 commands = pytest


### PR DESCRIPTION
## Summary
- Avoid content length checks in ApiClient and always attempt JSON parsing with graceful fallback
- Test API client and token manager with async mocks including undefined content length cases
- Add aiohttp and pytest-asyncio to test dependencies

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c708e58d8c8325a7a1cf2bbb833b67