### PR TITLE
chore: update tox deps for async tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,5 +4,6 @@ envlist = py
 [testenv]
 deps =
     pytest
-    requests
+    aiohttp
+    pytest-asyncio
 commands = pytest


### PR DESCRIPTION
## Summary
- drop requests from tox deps
- add aiohttp and pytest-asyncio
- retain pytest as default command

## Testing
- `pip install aiohttp pytest-asyncio`
- `pytest` *(fails: module 'custom_components.imou_control.token_manager' has no attribute 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68c708b4b70c832594ab4e9e898017ee