### PR TITLE
Refactor tests to async aiohttp mocks

### DIFF
--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -1,51 +1,67 @@
+import aiohttp
 import pytest
 
 
-class DummyResp:
+class FakeResponse:
     def __init__(self, data):
         self._data = data
-        self.content = b"1"
+        self.content_length = 1
 
-    def json(self):
+    async def json(self, content_type=None):
         return self._data
 
     def raise_for_status(self):
         pass
 
+    async def __aenter__(self):
+        return self
 
-def test_retry_on_token_error(monkeypatch, api_module):
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_retry_on_token_error(monkeypatch, api_module):
     calls = []
 
-    def fake_post(url, json, timeout):
+    def fake_post(self, url, json, **kwargs):
         calls.append(json["params"].get("token"))
         if len(calls) == 1:
             data = {"result": {"code": "TK1002", "msg": "bad"}}
         else:
             data = {"result": {"code": "0", "data": {}}}
-        return DummyResp(data)
+        return FakeResponse(data)
 
-    monkeypatch.setattr(api_module.requests, "post", fake_post)
+    monkeypatch.setattr(aiohttp.ClientSession, "post", fake_post)
     token = "t1"
 
-    def get_token():
+    async def get_token():
         return token
 
-    def refresh_token():
+    async def refresh_token():
         nonlocal token
         token = "t2"
         return token
 
     api = api_module.ApiClient("id", "sec", "http://host", get_token, refresh_token)
-    assert api.set_position("dev", 0.1, 0.2, 0.3)
+    assert await api.set_position("dev", 0.1, 0.2, 0.3)
     assert calls == ["t1", "t2"]
 
 
-def test_failure_raises(monkeypatch, api_module):
-    def fake_post(url, json, timeout):
+@pytest.mark.asyncio
+async def test_failure_raises(monkeypatch, api_module):
+    def fake_post(self, url, json, **kwargs):
         data = {"result": {"code": "123", "msg": "fail"}}
-        return DummyResp(data)
+        return FakeResponse(data)
 
-    monkeypatch.setattr(api_module.requests, "post", fake_post)
-    api = api_module.ApiClient("id", "sec", "http://host", lambda: "tok", lambda: "tok2")
+    monkeypatch.setattr(aiohttp.ClientSession, "post", fake_post)
+
+    async def get_token():
+        return "tok"
+
+    async def refresh_token():
+        return "tok2"
+
+    api = api_module.ApiClient("id", "sec", "http://host", get_token, refresh_token)
     with pytest.raises(RuntimeError):
-        api.set_position("dev", 0, 0, 0)
+        await api.set_position("dev", 0, 0, 0)


### PR DESCRIPTION
## Summary
- update API client tests to async style with aiohttp session mocks
- rewrite token manager tests to use async token handling

## Testing
- `pytest tests/test_api_client.py tests/test_token_manager.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7089ff13c8325bbd5866c25442d81