### PR TITLE
Auto-discover Imou devices and expose preset controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,11 @@ Após configurar as credenciais, a integração consulta a conta na nuvem e
 registra automaticamente todas as câmeras encontradas. Para cada dispositivo são
 criadas entidades numéricas (modo caixa) para os eixos **H** e **V** com faixa de
 `-1` a `1` e casas decimais. Após informar os valores desejados, um botão
-"Move" executa o comando para testar o posicionamento antes de salvar um preset.
-Os presets definidos ficam disponíveis em uma entidade *select* e podem ser
-acionados diretamente nela ou via serviço.
+"Move" executa o comando para testar o posicionamento. Cada câmera também possui
+uma entidade de texto para informar o nome do preset e um botão "Save Preset"
+que grava os valores atuais de H e V sob o nome escolhido. Os presets definidos
+ficam disponíveis em uma entidade *select* e podem ser acionados diretamente
+nela ou via serviço.
 
 ## Serviços disponíveis
 

--- a/README.md
+++ b/README.md
@@ -4,13 +4,14 @@ Integração personalizada para controlar câmeras Imou no Home Assistant.
 
 Após configurar as credenciais, a integração consulta a conta na nuvem e
 registra automaticamente todas as câmeras encontradas. Para cada dispositivo são
-criadas entidades numéricas (modo caixa) para os eixos **H** e **V** com faixa de
-`-1` a `1` e casas decimais. Após informar os valores desejados, um botão
-"Move" executa o comando para testar o posicionamento. Cada câmera também possui
-uma entidade de texto para informar o nome do preset e um botão "Save Preset"
-que grava os valores atuais de H e V sob o nome escolhido. Os presets definidos
-ficam disponíveis em uma entidade *select* e podem ser acionados diretamente
-nela ou via serviço.
+criadas entidades numéricas (slider com caixa) para os eixos **H** e **V** com
+faixa de `-1` a `1` e casas decimais. Após informar os valores desejados, um
+botão "Move" executa o comando para testar o posicionamento. Cada câmera também
+possui uma entidade de texto para informar o nome do preset e um botão "Save
+Preset" que grava os valores atuais de H e V sob o nome escolhido. Os presets
+definidos ficam disponíveis em uma entidade *select* e podem ser acionados
+diretamente nela ou via serviço. Todas as entidades são prefixadas com "Imou"
+e possuem traduções para inglês e português.
 
 ## Serviços disponíveis
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 Integração personalizada para controlar câmeras Imou no Home Assistant.
 
+Após configurar as credenciais, a integração consulta a conta na nuvem e
+registra automaticamente todas as câmeras encontradas. Para cada dispositivo são
+criadas entidades numéricas para os eixos **H** e **V**, permitindo testar
+posicionamentos diretamente pela UI antes de salvar um preset. Os presets
+definidos ficam disponíveis em uma entidade *select* e podem ser acionados
+diretamente nela ou via serviço.
+
 ## Serviços disponíveis
 
 ### `imou_control.set_position`
@@ -13,4 +20,6 @@ Registra localmente um preset (nome e h/v/z) para um dispositivo específico.
 ### `imou_control.call_preset`
 Posiciona a câmera em um preset previamente definido. Se o preset solicitado já
 for o último executado para o dispositivo, nenhum comando é enviado à nuvem
-para evitar consumo da cota mensal.
+para evitar consumo da cota mensal. Um evento `imou_control_preset_called` é
+emitido sempre que um preset é acionado, permitindo visualizar no histórico quem
+executou o comando.

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ Integração personalizada para controlar câmeras Imou no Home Assistant.
 
 Após configurar as credenciais, a integração consulta a conta na nuvem e
 registra automaticamente todas as câmeras encontradas. Para cada dispositivo são
-criadas entidades numéricas (slider com caixa) para os eixos **H** e **V** com
-faixa de `-1` a `1` e casas decimais. Após informar os valores desejados, um
-botão "Move" executa o comando para testar o posicionamento. Cada câmera também
+criadas entidades numéricas para os eixos **H** e **V** com faixa de `-1` a `1`
+e casas decimais. Após informar os valores desejados, um botão "Move" executa o
+comando para testar o posicionamento. Cada câmera também
 possui uma entidade de texto para informar o nome do preset e um botão "Save
 Preset" que grava os valores atuais de H e V sob o nome escolhido. Os presets
 definidos ficam disponíveis em uma entidade *select* e podem ser acionados

--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@ Integração personalizada para controlar câmeras Imou no Home Assistant.
 
 Após configurar as credenciais, a integração consulta a conta na nuvem e
 registra automaticamente todas as câmeras encontradas. Para cada dispositivo são
-criadas entidades numéricas para os eixos **H** e **V** com faixa de `-1` a `1`
-e casas decimais. Após informar os valores desejados, um botão "Move" executa o
-comando para testar o posicionamento. Cada câmera também
-possui uma entidade de texto para informar o nome do preset e um botão "Save
-Preset" que grava os valores atuais de H e V sob o nome escolhido. Os presets
-definidos ficam disponíveis em uma entidade *select* e podem ser acionados
-diretamente nela ou via serviço. Todas as entidades são prefixadas com "Imou"
-e possuem traduções para inglês e português.
+criadas as entidades numéricas **Imou Horizontal** e **Imou Vertical** com faixa de
+`-1` a `1` e casas decimais. Após informar os valores desejados, o botão
+**Imou Mover** executa o comando para testar o posicionamento. Cada câmera também
+possui a entidade de texto **Imou Nome do Preset** e o botão **Imou Salvar
+Predefinição**, que grava os valores atuais de H e V sob o nome escolhido. Os
+presets definidos ficam disponíveis na entidade *select* **Imou Predefinições** e
+podem ser acionados diretamente nela ou via serviço. Todas as entidades são
+prefixadas com "Imou" e possuem traduções para inglês e português.
 
 Os presets gravados são mantidos entre reinicializações do Home Assistant.
 

--- a/README.md
+++ b/README.md
@@ -4,10 +4,11 @@ Integração personalizada para controlar câmeras Imou no Home Assistant.
 
 Após configurar as credenciais, a integração consulta a conta na nuvem e
 registra automaticamente todas as câmeras encontradas. Para cada dispositivo são
-criadas entidades numéricas para os eixos **H** e **V**, permitindo testar
-posicionamentos diretamente pela UI antes de salvar um preset. Os presets
-definidos ficam disponíveis em uma entidade *select* e podem ser acionados
-diretamente nela ou via serviço.
+criadas entidades numéricas (modo caixa) para os eixos **H** e **V** com faixa de
+`-1` a `1` e casas decimais. Após informar os valores desejados, um botão
+"Move" executa o comando para testar o posicionamento antes de salvar um preset.
+Os presets definidos ficam disponíveis em uma entidade *select* e podem ser
+acionados diretamente nela ou via serviço.
 
 ## Serviços disponíveis
 
@@ -16,6 +17,9 @@ Move a câmera para uma posição absoluta definindo os valores `h`, `v` e `z`.
 
 ### `imou_control.define_preset`
 Registra localmente um preset (nome e h/v/z) para um dispositivo específico.
+
+### `imou_control.save_preset`
+Registra um preset usando os valores atuais das entidades de posição.
 
 ### `imou_control.call_preset`
 Posiciona a câmera em um preset previamente definido. Se o preset solicitado já

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ definidos ficam disponíveis em uma entidade *select* e podem ser acionados
 diretamente nela ou via serviço. Todas as entidades são prefixadas com "Imou"
 e possuem traduções para inglês e português.
 
+Os presets gravados são mantidos entre reinicializações do Home Assistant.
+
 ## Serviços disponíveis
 
 ### `imou_control.set_position`

--- a/custom_components/imou_control/__init__.py
+++ b/custom_components/imou_control/__init__.py
@@ -38,7 +38,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     }
 
     registry = dr.async_get(hass)
-    devices_info = await hass.async_add_executor_job(api.list_devices)
+    try:
+        devices_info = await hass.async_add_executor_job(api.list_devices)
+    except Exception as err:
+        _LOGGER.error("Não foi possível obter a lista de dispositivos: %s", err)
+        devices_info = []
     for info in devices_info:
         device_id = info.get("deviceId")
         name = info.get("deviceName", f"Imou {device_id}")

--- a/custom_components/imou_control/__init__.py
+++ b/custom_components/imou_control/__init__.py
@@ -6,7 +6,13 @@ from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers import device_registry as dr
 
-from .const import DOMAIN, CONF_APP_ID, CONF_APP_SECRET, CONF_URL_BASE
+from .const import (
+    DOMAIN,
+    CONF_APP_ID,
+    CONF_APP_SECRET,
+    CONF_URL_BASE,
+    EVENT_PRESET_CALLED,
+)
 from .token_manager import TokenManager
 from .api import ApiClient
 
@@ -20,14 +26,50 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     app_secret = entry.data[CONF_APP_SECRET]
     url_base   = entry.data[CONF_URL_BASE]
 
-    tm  = TokenManager(app_id, app_secret, url_base)
+    tm = TokenManager(app_id, app_secret, url_base)
     api = ApiClient(app_id, app_secret, url_base, tm.get_token, tm.refresh_token)
 
     hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN][entry.entry_id] = {"tm": tm, "api": api, "devices": {}}
+    data_entry = hass.data[DOMAIN][entry.entry_id] = {
+        "tm": tm,
+        "api": api,
+        "devices": {},
+        "devices_by_name": {},
+    }
+
+    registry = dr.async_get(hass)
+    devices_info = await hass.async_add_executor_job(api.list_devices)
+    for info in devices_info:
+        device_id = info.get("deviceId")
+        name = info.get("deviceName", f"Imou {device_id}")
+        data_entry["devices"][device_id] = {
+            "name": name,
+            "presets": {},
+            "last_preset": None,
+            "coords": {"h": 0.0, "v": 0.0, "z": 0.0},
+            "select_entity": None,
+        }
+        data_entry["devices_by_name"][name] = device_id
+        registry.async_get_or_create(
+            config_entry_id=entry.entry_id,
+            identifiers={(DOMAIN, device_id)},
+            manufacturer="Imou",
+            name=name,
+        )
+
+    await hass.config_entries.async_forward_entry_setups(entry, ["number", "select"])
+
+    def resolve_device_id(device: str) -> str | None:
+        if device in data_entry["devices"]:
+            return device
+        return data_entry["devices_by_name"].get(device)
 
     async def srv_set_position(call: ServiceCall):
-        device_id = call.data["device_id"]
+        device = call.data["device"]
+        device_id = resolve_device_id(device)
+        if not device_id:
+            _LOGGER.warning("Dispositivo %s não encontrado", device)
+            return
         h = float(call.data["h"])
         v = float(call.data["v"])
         z = float(call.data.get("z", 0.0))
@@ -40,53 +82,61 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             raise
 
     hass.services.async_register(
-        DOMAIN, "set_position", srv_set_position,
-        schema=vol.Schema({
-            vol.Required("device_id"): cv.string,
-            vol.Required("h"): vol.Coerce(float),
-            vol.Required("v"): vol.Coerce(float),
-            vol.Optional("z", default=0.0): vol.Coerce(float),
-        })
+        DOMAIN,
+        "set_position",
+        srv_set_position,
+        schema=vol.Schema(
+            {
+                vol.Required("device"): cv.string,
+                vol.Required("h"): vol.Coerce(float),
+                vol.Required("v"): vol.Coerce(float),
+                vol.Optional("z", default=0.0): vol.Coerce(float),
+            }
+        ),
     )
 
     async def srv_define_preset(call: ServiceCall):
-        device_id = call.data["device_id"]
+        device = call.data["device"]
+        device_id = resolve_device_id(device)
+        if not device_id:
+            _LOGGER.warning("Dispositivo %s não encontrado", device)
+            return
         preset = call.data["preset"]
-        name = call.data.get("name", f"Imou {device_id}")
         h = float(call.data["h"])
         v = float(call.data["v"])
         z = float(call.data.get("z", 0.0))
 
         data = hass.data[DOMAIN][entry.entry_id]
-        devices = data["devices"]
-        dev = devices.setdefault(device_id, {"name": name, "presets": {}, "last_preset": None})
-        dev["name"] = name
+        dev = data["devices"][device_id]
+        if preset in dev["presets"]:
+            _LOGGER.warning("Preset %s já definido para %s", preset, device_id)
+            return
         dev["presets"][preset] = (h, v, z)
-
-        registry = dr.async_get(hass)
-        registry.async_get_or_create(
-            config_entry_id=entry.entry_id,
-            identifiers={(DOMAIN, device_id)},
-            manufacturer="Imou",
-            name=name,
-        )
+        sel = dev.get("select_entity")
+        if sel is not None:
+            sel.async_update_presets()
 
     hass.services.async_register(
         DOMAIN,
         "define_preset",
         srv_define_preset,
-        schema=vol.Schema({
-            vol.Required("device_id"): cv.string,
-            vol.Required("preset"): cv.string,
-            vol.Required("h"): vol.Coerce(float),
-            vol.Required("v"): vol.Coerce(float),
-            vol.Optional("z", default=0.0): vol.Coerce(float),
-            vol.Optional("name"): cv.string,
-        }),
+        schema=vol.Schema(
+            {
+                vol.Required("device"): cv.string,
+                vol.Required("preset"): cv.string,
+                vol.Required("h"): vol.Coerce(float),
+                vol.Required("v"): vol.Coerce(float),
+                vol.Optional("z", default=0.0): vol.Coerce(float),
+            }
+        ),
     )
 
     async def srv_call_preset(call: ServiceCall):
-        device_id = call.data["device_id"]
+        device = call.data["device"]
+        device_id = resolve_device_id(device)
+        if not device_id:
+            _LOGGER.warning("Dispositivo %s não encontrado", device)
+            return
         preset = call.data["preset"]
 
         data = hass.data[DOMAIN][entry.entry_id]
@@ -106,21 +156,31 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         try:
             await hass.async_add_executor_job(api.set_position, device_id, h, v, z)
             dev["last_preset"] = preset
+            hass.bus.async_fire(
+                EVENT_PRESET_CALLED,
+                {"device": device_id, "preset": preset},
+                context=call.context,
+            )
         except Exception as e:
-            _LOGGER.exception("Falha ao acionar preset %s em %s: %s", preset, device_id, e)
+            _LOGGER.exception(
+                "Falha ao acionar preset %s em %s: %s", preset, device_id, e
+            )
 
     hass.services.async_register(
         DOMAIN,
         "call_preset",
         srv_call_preset,
-        schema=vol.Schema({
-            vol.Required("device_id"): cv.string,
-            vol.Required("preset"): cv.string,
-        }),
+        schema=vol.Schema(
+            {
+                vol.Required("device"): cv.string,
+                vol.Required("preset"): cv.string,
+            }
+        ),
     )
 
     return True
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    await hass.config_entries.async_unload_platforms(entry, ["number", "select"])
     hass.data[DOMAIN].pop(entry.entry_id, None)
     return True

--- a/custom_components/imou_control/__init__.py
+++ b/custom_components/imou_control/__init__.py
@@ -45,7 +45,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         devices_info = []
     for info in devices_info:
         device_id = info.get("deviceId")
-        name = info.get("deviceName", f"Imou {device_id}")
+        raw_name = info.get("deviceName") or device_id
+        name = f"Imou {raw_name}"
         data_entry["devices"][device_id] = {
             "name": name,
             "presets": {},
@@ -55,6 +56,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             "preset_name": "",
         }
         data_entry["devices_by_name"][name] = device_id
+        data_entry["devices_by_name"][raw_name] = device_id
         registry.async_get_or_create(
             config_entry_id=entry.entry_id,
             identifiers={(DOMAIN, device_id)},

--- a/custom_components/imou_control/__init__.py
+++ b/custom_components/imou_control/__init__.py
@@ -52,6 +52,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             "last_preset": None,
             "coords": {"h": 0.0, "v": 0.0, "z": 0.0},
             "select_entity": None,
+            "preset_name": "",
         }
         data_entry["devices_by_name"][name] = device_id
         registry.async_get_or_create(
@@ -61,7 +62,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             name=name,
         )
 
-    await hass.config_entries.async_forward_entry_setups(entry, ["number", "select", "button"])
+    await hass.config_entries.async_forward_entry_setups(entry, ["number", "select", "button", "text"])
 
     def resolve_device_id(device: str) -> str | None:
         if device in data_entry["devices"]:
@@ -218,6 +219,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    await hass.config_entries.async_unload_platforms(entry, ["number", "select", "button"])
+    await hass.config_entries.async_unload_platforms(entry, ["number", "select", "button", "text"])
     hass.data[DOMAIN].pop(entry.entry_id, None)
     return True

--- a/custom_components/imou_control/api.py
+++ b/custom_components/imou_control/api.py
@@ -109,27 +109,27 @@ class ApiClient:
 
     def list_devices(self) -> List[Dict[str, Any]]:
         """Obtém a lista de dispositivos vinculados à conta Imou."""
-        params = {"pageNo": 1, "pageSize": 100}
+        params = {
+            "bindId": "-1",
+            "limit": 128,
+            "type": "bindAndShare",
+            "needApInfo": "false",
+        }
         try:
             data = self._call_with_retry(DEVICE_LIST_ENDPOINT, params, include_token=True)
         except Exception as err:
             logging.getLogger(__name__).error("Falha ao listar dispositivos: %s", err)
             return []
 
-        result = data.get("result") or data
+        result = data.get("result") or {}
         devices = (
-            result.get("data")
+            (result.get("data") or {}).get("deviceList")
             or result.get("devices")
             or result.get("list")
             or []
         )
 
-        if isinstance(devices, dict):
-            for key in ("deviceList", "items"):
-                if key in devices:
-                    return devices[key]
-            return []
-        return devices
+        return devices if isinstance(devices, list) else []
 
     # Exemplo de uso genérico (se precisar depois):
     # def call_any(self, path: str, params: Dict[str, Any], require_token: bool = True) -> Dict[str, Any]:

--- a/custom_components/imou_control/api.py
+++ b/custom_components/imou_control/api.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 import uuid
 import requests
-from typing import Any, Dict, Callable, Optional, Tuple
-from .const import PTZ_LOCATION_ENDPOINT
+from typing import Any, Dict, Callable, Optional, Tuple, List
+from .const import PTZ_LOCATION_ENDPOINT, DEVICE_LIST_ENDPOINT
 from .utils import make_system
 
 # Códigos de erro que indicam token inválido/expirado
@@ -105,6 +105,12 @@ class ApiClient:
         data = self._call_with_retry(PTZ_LOCATION_ENDPOINT, params, include_token=True)
         # sucesso já garantido por _call_with_retry (code == "0")
         return True
+
+    def list_devices(self) -> List[Dict[str, Any]]:
+        """Obtém a lista de dispositivos vinculados à conta Imou."""
+        data = self._call_with_retry(DEVICE_LIST_ENDPOINT, {}, include_token=True)
+        result = data.get("result") or {}
+        return result.get("data", [])
 
     # Exemplo de uso genérico (se precisar depois):
     # def call_any(self, path: str, params: Dict[str, Any], require_token: bool = True) -> Dict[str, Any]:

--- a/custom_components/imou_control/button.py
+++ b/custom_components/imou_control/button.py
@@ -14,18 +14,11 @@ class ImouMoveButton(ButtonEntity):
         self._device_id = device_id
         self._data = data
         self._attr_should_poll = False
-
-    @property
-    def name(self) -> str:
-        return f"{self._data['name']} Move"
-
-    @property
-    def unique_id(self) -> str:
-        return f"{self._device_id}_move"
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        return DeviceInfo(identifiers={(DOMAIN, self._device_id)})
+        self._attr_unique_id = f"{self._device_id}_move"
+        self._attr_device_info = DeviceInfo(identifiers={(DOMAIN, self._device_id)})
+        self._attr_has_entity_name = False
+        self._attr_translation_key = "move"
+        self._attr_translation_placeholders = {"device": data["name"]}
 
     async def async_press(self) -> None:
         h = self._data["coords"]["h"]
@@ -42,18 +35,11 @@ class ImouSavePresetButton(ButtonEntity):
         self._device_id = device_id
         self._data = data
         self._attr_should_poll = False
-
-    @property
-    def name(self) -> str:
-        return f"{self._data['name']} Save Preset"
-
-    @property
-    def unique_id(self) -> str:
-        return f"{self._device_id}_save_preset"
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        return DeviceInfo(identifiers={(DOMAIN, self._device_id)})
+        self._attr_unique_id = f"{self._device_id}_save_preset"
+        self._attr_device_info = DeviceInfo(identifiers={(DOMAIN, self._device_id)})
+        self._attr_has_entity_name = False
+        self._attr_translation_key = "save_preset"
+        self._attr_translation_placeholders = {"device": data["name"]}
 
     async def async_press(self) -> None:
         preset = self._data.get("preset_name")

--- a/custom_components/imou_control/button.py
+++ b/custom_components/imou_control/button.py
@@ -35,10 +35,43 @@ class ImouMoveButton(ButtonEntity):
             self._api.set_position, self._device_id, h, v, z
         )
 
+
+class ImouSavePresetButton(ButtonEntity):
+    def __init__(self, hass: HomeAssistant, device_id: str, data: dict):
+        self._hass = hass
+        self._device_id = device_id
+        self._data = data
+        self._attr_should_poll = False
+
+    @property
+    def name(self) -> str:
+        return f"{self._data['name']} Save Preset"
+
+    @property
+    def unique_id(self) -> str:
+        return f"{self._device_id}_save_preset"
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        return DeviceInfo(identifiers={(DOMAIN, self._device_id)})
+
+    async def async_press(self) -> None:
+        preset = self._data.get("preset_name")
+        if not preset:
+            return
+        await self._hass.services.async_call(
+            DOMAIN,
+            "save_preset",
+            {"device": self._device_id, "preset": preset},
+            blocking=True,
+            context=self.context,
+        )
+
 async def async_setup_entry(hass: HomeAssistant, entry, async_add_entities):
     data = hass.data[DOMAIN][entry.entry_id]
     api = data["api"]
     entities = []
     for device_id, dev in data["devices"].items():
         entities.append(ImouMoveButton(hass, api, device_id, dev))
+        entities.append(ImouSavePresetButton(hass, device_id, dev))
     async_add_entities(entities)

--- a/custom_components/imou_control/button.py
+++ b/custom_components/imou_control/button.py
@@ -15,7 +15,11 @@ class ImouMoveButton(ButtonEntity):
         self._data = data
         self._attr_should_poll = False
         self._attr_unique_id = f"{self._device_id}_move"
-        self._attr_device_info = DeviceInfo(identifiers={(DOMAIN, self._device_id)})
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, self._device_id)},
+            manufacturer="Imou",
+            name=data["name"],
+        )
         self._attr_has_entity_name = True
         self._attr_translation_key = "move"
 
@@ -35,7 +39,11 @@ class ImouSavePresetButton(ButtonEntity):
         self._data = data
         self._attr_should_poll = False
         self._attr_unique_id = f"{self._device_id}_save_preset"
-        self._attr_device_info = DeviceInfo(identifiers={(DOMAIN, self._device_id)})
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, self._device_id)},
+            manufacturer="Imou",
+            name=data["name"],
+        )
         self._attr_has_entity_name = True
         self._attr_translation_key = "save_preset"
 

--- a/custom_components/imou_control/button.py
+++ b/custom_components/imou_control/button.py
@@ -64,7 +64,7 @@ class ImouSavePresetButton(ButtonEntity):
             "save_preset",
             {"device": self._device_id, "preset": preset},
             blocking=True,
-            context=self.context,
+            context=self._context,
         )
 
 async def async_setup_entry(hass: HomeAssistant, entry, async_add_entities):

--- a/custom_components/imou_control/button.py
+++ b/custom_components/imou_control/button.py
@@ -16,9 +16,8 @@ class ImouMoveButton(ButtonEntity):
         self._attr_should_poll = False
         self._attr_unique_id = f"{self._device_id}_move"
         self._attr_device_info = DeviceInfo(identifiers={(DOMAIN, self._device_id)})
-        self._attr_has_entity_name = False
+        self._attr_has_entity_name = True
         self._attr_translation_key = "move"
-        self._attr_translation_placeholders = {"device": data["name"]}
 
     async def async_press(self) -> None:
         h = self._data["coords"]["h"]
@@ -37,9 +36,8 @@ class ImouSavePresetButton(ButtonEntity):
         self._attr_should_poll = False
         self._attr_unique_id = f"{self._device_id}_save_preset"
         self._attr_device_info = DeviceInfo(identifiers={(DOMAIN, self._device_id)})
-        self._attr_has_entity_name = False
+        self._attr_has_entity_name = True
         self._attr_translation_key = "save_preset"
-        self._attr_translation_placeholders = {"device": data["name"]}
 
     async def async_press(self) -> None:
         preset = self._data.get("preset_name")

--- a/custom_components/imou_control/button.py
+++ b/custom_components/imou_control/button.py
@@ -20,7 +20,7 @@ class ImouMoveButton(ButtonEntity):
             manufacturer="Imou",
             name=data["name"],
         )
-        self._attr_has_entity_name = True
+        self._attr_has_entity_name = False
         self._attr_translation_key = "move"
 
     async def async_press(self) -> None:
@@ -44,7 +44,7 @@ class ImouSavePresetButton(ButtonEntity):
             manufacturer="Imou",
             name=data["name"],
         )
-        self._attr_has_entity_name = True
+        self._attr_has_entity_name = False
         self._attr_translation_key = "save_preset"
 
     async def async_press(self) -> None:

--- a/custom_components/imou_control/button.py
+++ b/custom_components/imou_control/button.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from homeassistant.components.button import ButtonEntity
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
+
+
+class ImouMoveButton(ButtonEntity):
+    def __init__(self, hass: HomeAssistant, api, device_id: str, data: dict):
+        self._hass = hass
+        self._api = api
+        self._device_id = device_id
+        self._data = data
+        self._attr_should_poll = False
+
+    @property
+    def name(self) -> str:
+        return f"{self._data['name']} Move"
+
+    @property
+    def unique_id(self) -> str:
+        return f"{self._device_id}_move"
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        return DeviceInfo(identifiers={(DOMAIN, self._device_id)})
+
+    async def async_press(self) -> None:
+        h = self._data["coords"]["h"]
+        v = self._data["coords"]["v"]
+        z = self._data["coords"].get("z", 0.0)
+        await self._hass.async_add_executor_job(
+            self._api.set_position, self._device_id, h, v, z
+        )
+
+async def async_setup_entry(hass: HomeAssistant, entry, async_add_entities):
+    data = hass.data[DOMAIN][entry.entry_id]
+    api = data["api"]
+    entities = []
+    for device_id, dev in data["devices"].items():
+        entities.append(ImouMoveButton(hass, api, device_id, dev))
+    async_add_entities(entities)

--- a/custom_components/imou_control/const.py
+++ b/custom_components/imou_control/const.py
@@ -8,3 +8,7 @@ CONF_URL_BASE = "url_base"
 # Endpoints padrão da Open API (relativos ao url_base)
 TOKEN_ENDPOINT = "/openapi/accessToken"
 PTZ_LOCATION_ENDPOINT = "/openapi/controlLocationPTZ"
+DEVICE_LIST_ENDPOINT = "/openapi/device/list"
+
+# Nome do evento disparado quando um preset é chamado
+EVENT_PRESET_CALLED = "imou_control_preset_called"

--- a/custom_components/imou_control/const.py
+++ b/custom_components/imou_control/const.py
@@ -8,7 +8,7 @@ CONF_URL_BASE = "url_base"
 # Endpoints padrão da Open API (relativos ao url_base)
 TOKEN_ENDPOINT = "/openapi/accessToken"
 PTZ_LOCATION_ENDPOINT = "/openapi/controlLocationPTZ"
-DEVICE_LIST_ENDPOINT = "/openapi/device/list"
+DEVICE_LIST_ENDPOINT = "/openapi/deviceOpenList"
 
 # Nome do evento disparado quando um preset é chamado
 EVENT_PRESET_CALLED = "imou_control_preset_called"

--- a/custom_components/imou_control/manifest.json
+++ b/custom_components/imou_control/manifest.json
@@ -1,10 +1,10 @@
 {
   "domain": "imou_control",
   "name": "Imou Control",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "config_flow": true,
   "requirements": ["requests>=2.28.0"],
   "codeowners": ["@you"],
   "iot_class": "cloud_polling",
-  "platforms": ["number", "select"]
+  "platforms": ["number", "select", "button"]
 }

--- a/custom_components/imou_control/manifest.json
+++ b/custom_components/imou_control/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "imou_control",
   "name": "Imou Control",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "config_flow": true,
   "requirements": ["requests>=2.28.0"],
   "codeowners": ["@you"],

--- a/custom_components/imou_control/manifest.json
+++ b/custom_components/imou_control/manifest.json
@@ -6,5 +6,5 @@
   "requirements": ["requests>=2.28.0"],
   "codeowners": ["@you"],
   "iot_class": "cloud_polling",
-  "platforms": ["number", "select", "button"]
+  "platforms": ["number", "select", "button", "text"]
 }

--- a/custom_components/imou_control/manifest.json
+++ b/custom_components/imou_control/manifest.json
@@ -1,10 +1,10 @@
 {
   "domain": "imou_control",
   "name": "Imou Control",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "config_flow": true,
   "requirements": ["requests>=2.28.0"],
   "codeowners": ["@you"],
   "iot_class": "cloud_polling",
-  "platforms": []
+  "platforms": ["number", "select"]
 }

--- a/custom_components/imou_control/number.py
+++ b/custom_components/imou_control/number.py
@@ -14,13 +14,12 @@ class ImouAxisNumber(NumberEntity):
         self._axis = axis
         self._data = data
         self._attr_should_poll = False
-        self._attr_mode = NumberMode.BOX | NumberMode.SLIDER
+        self._attr_mode = NumberMode.BOX
         self._attr_unique_id = f"{device_id}_{axis}"
         self._attr_device_info = DeviceInfo(identifiers={(DOMAIN, device_id)})
-        self._attr_has_entity_name = False
+        self._attr_has_entity_name = True
         key = "horizontal" if axis == "h" else "vertical"
         self._attr_translation_key = key
-        self._attr_translation_placeholders = {"device": data["name"]}
 
         self._attr_native_min_value = -1.0
         self._attr_native_max_value = 1.0

--- a/custom_components/imou_control/number.py
+++ b/custom_components/imou_control/number.py
@@ -21,7 +21,7 @@ class ImouAxisNumber(NumberEntity):
             manufacturer="Imou",
             name=data["name"],
         )
-        self._attr_has_entity_name = True
+        self._attr_has_entity_name = False
         key = "horizontal" if axis == "h" else "vertical"
         self._attr_translation_key = key
 

--- a/custom_components/imou_control/number.py
+++ b/custom_components/imou_control/number.py
@@ -14,12 +14,13 @@ class ImouAxisNumber(NumberEntity):
         self._axis = axis
         self._data = data
         self._attr_should_poll = False
-        self._attr_mode = NumberMode.SLIDER
-
-        axis_name = {"h": "Horizontal", "v": "Vertical"}.get(axis, axis)
-        self._attr_name = f"{data['name']} {axis_name}"
+        self._attr_mode = NumberMode.BOX | NumberMode.SLIDER
         self._attr_unique_id = f"{device_id}_{axis}"
         self._attr_device_info = DeviceInfo(identifiers={(DOMAIN, device_id)})
+        self._attr_has_entity_name = False
+        key = "horizontal" if axis == "h" else "vertical"
+        self._attr_translation_key = key
+        self._attr_translation_placeholders = {"device": data["name"]}
 
         self._attr_native_min_value = -1.0
         self._attr_native_max_value = 1.0
@@ -30,6 +31,7 @@ class ImouAxisNumber(NumberEntity):
         self._data["coords"][self._axis] = float(value)
         self._attr_native_value = float(value)
         self.async_write_ha_state()
+
 
 async def async_setup_entry(hass: HomeAssistant, entry, async_add_entities):
     data = hass.data[DOMAIN][entry.entry_id]

--- a/custom_components/imou_control/number.py
+++ b/custom_components/imou_control/number.py
@@ -16,7 +16,11 @@ class ImouAxisNumber(NumberEntity):
         self._attr_should_poll = False
         self._attr_mode = NumberMode.BOX
         self._attr_unique_id = f"{device_id}_{axis}"
-        self._attr_device_info = DeviceInfo(identifiers={(DOMAIN, device_id)})
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, device_id)},
+            manufacturer="Imou",
+            name=data["name"],
+        )
         self._attr_has_entity_name = True
         key = "horizontal" if axis == "h" else "vertical"
         self._attr_translation_key = key

--- a/custom_components/imou_control/number.py
+++ b/custom_components/imou_control/number.py
@@ -6,6 +6,7 @@ from homeassistant.core import HomeAssistant
 
 from .const import DOMAIN
 
+
 class ImouAxisNumber(NumberEntity):
     def __init__(self, hass: HomeAssistant, device_id: str, axis: str, data: dict):
         self._hass = hass
@@ -13,39 +14,21 @@ class ImouAxisNumber(NumberEntity):
         self._axis = axis
         self._data = data
         self._attr_should_poll = False
-        self._attr_mode = NumberMode.BOX
+        self._attr_mode = NumberMode.SLIDER
 
-    @property
-    def name(self) -> str:
-        axis_name = {"h": "Horizontal", "v": "Vertical"}.get(self._axis, self._axis)
-        return f"{self._data['name']} {axis_name}"
+        axis_name = {"h": "Horizontal", "v": "Vertical"}.get(axis, axis)
+        self._attr_name = f"{data['name']} {axis_name}"
+        self._attr_unique_id = f"{device_id}_{axis}"
+        self._attr_device_info = DeviceInfo(identifiers={(DOMAIN, device_id)})
 
-    @property
-    def unique_id(self) -> str:
-        return f"{self._device_id}_{self._axis}"
+        self._attr_native_min_value = -1.0
+        self._attr_native_max_value = 1.0
+        self._attr_native_step = 0.01
+        self._attr_native_value = data["coords"][axis]
 
-    @property
-    def min_value(self) -> float:
-        return -1.0
-
-    @property
-    def max_value(self) -> float:
-        return 1.0
-
-    @property
-    def step(self) -> float:
-        return 0.01
-
-    @property
-    def value(self) -> float:
-        return self._data["coords"][self._axis]
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        return DeviceInfo(identifiers={(DOMAIN, self._device_id)})
-
-    async def async_set_value(self, value: float) -> None:
+    async def async_set_native_value(self, value: float) -> None:
         self._data["coords"][self._axis] = float(value)
+        self._attr_native_value = float(value)
         self.async_write_ha_state()
 
 async def async_setup_entry(hass: HomeAssistant, entry, async_add_entities):

--- a/custom_components/imou_control/number.py
+++ b/custom_components/imou_control/number.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from homeassistant.components.number import NumberEntity
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
+
+class ImouAxisNumber(NumberEntity):
+    def __init__(self, hass: HomeAssistant, api, device_id: str, axis: str, data: dict):
+        self._hass = hass
+        self._api = api
+        self._device_id = device_id
+        self._axis = axis
+        self._data = data
+        self._attr_should_poll = False
+
+    @property
+    def name(self) -> str:
+        axis_name = {"h": "Horizontal", "v": "Vertical"}.get(self._axis, self._axis)
+        return f"{self._data['name']} {axis_name}"
+
+    @property
+    def unique_id(self) -> str:
+        return f"{self._device_id}_{self._axis}"
+
+    @property
+    def min_value(self) -> float:
+        return -180.0
+
+    @property
+    def max_value(self) -> float:
+        return 180.0
+
+    @property
+    def step(self) -> float:
+        return 1.0
+
+    @property
+    def value(self) -> float:
+        return self._data["coords"][self._axis]
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        return DeviceInfo(identifiers={(DOMAIN, self._device_id)})
+
+    async def async_set_value(self, value: float) -> None:
+        self._data["coords"][self._axis] = float(value)
+        h = self._data["coords"]["h"]
+        v = self._data["coords"]["v"]
+        z = self._data["coords"].get("z", 0.0)
+        await self._hass.async_add_executor_job(
+            self._api.set_position, self._device_id, h, v, z
+        )
+        self.async_write_ha_state()
+
+async def async_setup_entry(hass: HomeAssistant, entry, async_add_entities):
+    data = hass.data[DOMAIN][entry.entry_id]
+    api = data["api"]
+    entities = []
+    for device_id, dev in data["devices"].items():
+        entities.append(ImouAxisNumber(hass, api, device_id, "h", dev))
+        entities.append(ImouAxisNumber(hass, api, device_id, "v", dev))
+    async_add_entities(entities)

--- a/custom_components/imou_control/select.py
+++ b/custom_components/imou_control/select.py
@@ -16,7 +16,11 @@ class ImouPresetSelect(SelectEntity):
         self._attr_should_poll = False
         self._attr_options = list(data["presets"].keys())
         self._attr_unique_id = f"{self._device_id}_presets"
-        self._attr_device_info = DeviceInfo(identifiers={(DOMAIN, self._device_id)})
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, self._device_id)},
+            manufacturer="Imou",
+            name=data["name"],
+        )
         self._attr_has_entity_name = True
         self._attr_translation_key = "presets"
 

--- a/custom_components/imou_control/select.py
+++ b/custom_components/imou_control/select.py
@@ -21,7 +21,7 @@ class ImouPresetSelect(SelectEntity):
             manufacturer="Imou",
             name=data["name"],
         )
-        self._attr_has_entity_name = True
+        self._attr_has_entity_name = False
         self._attr_translation_key = "presets"
 
     @property

--- a/custom_components/imou_control/select.py
+++ b/custom_components/imou_control/select.py
@@ -14,29 +14,22 @@ class ImouPresetSelect(SelectEntity):
         self._data = data
         self._attr_should_poll = False
         self._attr_options = list(data["presets"].keys())
-
-    @property
-    def name(self) -> str:
-        return f"{self._data['name']} Presets"
-
-    @property
-    def unique_id(self) -> str:
-        return f"{self._device_id}_presets"
+        self._attr_unique_id = f"{self._device_id}_presets"
+        self._attr_device_info = DeviceInfo(identifiers={(DOMAIN, self._device_id)})
+        self._attr_has_entity_name = False
+        self._attr_translation_key = "presets"
+        self._attr_translation_placeholders = {"device": data["name"]}
 
     @property
     def current_option(self) -> str | None:
         return self._data.get("last_preset")
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        return DeviceInfo(identifiers={(DOMAIN, self._device_id)})
 
     async def async_select_option(self, option: str) -> None:
         await self._hass.services.async_call(
             DOMAIN,
             "call_preset",
             {"device": self._device_id, "preset": option},
-            context=self.context,
+            context=self._context,
         )
         self._data["last_preset"] = option
         self.async_write_ha_state()

--- a/custom_components/imou_control/select.py
+++ b/custom_components/imou_control/select.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from homeassistant.components.select import SelectEntity
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
+
+class ImouPresetSelect(SelectEntity):
+    def __init__(self, hass: HomeAssistant, api, device_id: str, data: dict):
+        self._hass = hass
+        self._api = api
+        self._device_id = device_id
+        self._data = data
+        self._attr_should_poll = False
+        self._attr_options = list(data["presets"].keys())
+
+    @property
+    def name(self) -> str:
+        return f"{self._data['name']} Presets"
+
+    @property
+    def unique_id(self) -> str:
+        return f"{self._device_id}_presets"
+
+    @property
+    def current_option(self) -> str | None:
+        return self._data.get("last_preset")
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        return DeviceInfo(identifiers={(DOMAIN, self._device_id)})
+
+    async def async_select_option(self, option: str) -> None:
+        await self._hass.services.async_call(
+            DOMAIN,
+            "call_preset",
+            {"device": self._device_id, "preset": option},
+            context=self.context,
+        )
+        self._data["last_preset"] = option
+        self.async_write_ha_state()
+
+    def async_update_presets(self) -> None:
+        self._attr_options = list(self._data["presets"].keys())
+        self.async_write_ha_state()
+
+async def async_setup_entry(hass: HomeAssistant, entry, async_add_entities):
+    data = hass.data[DOMAIN][entry.entry_id]
+    api = data["api"]
+    entities = []
+    for device_id, dev in data["devices"].items():
+        ent = ImouPresetSelect(hass, api, device_id, dev)
+        dev["select_entity"] = ent
+        entities.append(ent)
+    async_add_entities(entities)

--- a/custom_components/imou_control/select.py
+++ b/custom_components/imou_control/select.py
@@ -6,6 +6,7 @@ from homeassistant.core import HomeAssistant
 
 from .const import DOMAIN
 
+
 class ImouPresetSelect(SelectEntity):
     def __init__(self, hass: HomeAssistant, api, device_id: str, data: dict):
         self._hass = hass
@@ -16,9 +17,8 @@ class ImouPresetSelect(SelectEntity):
         self._attr_options = list(data["presets"].keys())
         self._attr_unique_id = f"{self._device_id}_presets"
         self._attr_device_info = DeviceInfo(identifiers={(DOMAIN, self._device_id)})
-        self._attr_has_entity_name = False
+        self._attr_has_entity_name = True
         self._attr_translation_key = "presets"
-        self._attr_translation_placeholders = {"device": data["name"]}
 
     @property
     def current_option(self) -> str | None:

--- a/custom_components/imou_control/services.yaml
+++ b/custom_components/imou_control/services.yaml
@@ -2,9 +2,9 @@ set_position:
   name: Ajustar posição da câmera (PTZ absoluto)
   description: Move a câmera para a posição absoluta por h/v/z usando a API da Imou.
   fields:
-    device_id:
-      description: Device ID da câmera na Imou
-      example: 5250FACPBV99ADE
+    device:
+      description: Nome ou ID do dispositivo
+      example: Camera Sala
     h:
       description: Posição horizontal (-1..1, conforme sua API)
       example: -0.60
@@ -19,9 +19,9 @@ define_preset:
   name: Definir preset de posição
   description: Armazena localmente um preset com h/v/z para o dispositivo.
   fields:
-    device_id:
-      description: Device ID da câmera na Imou
-      example: 5250FACPBV99ADE
+    device:
+      description: Nome ou ID do dispositivo
+      example: Camera Sala
     preset:
       description: Nome do preset
       example: sala
@@ -34,17 +34,14 @@ define_preset:
     z:
       description: Zoom (se aplicável)
       example: 0
-    name:
-      description: Nome amigável do dispositivo (opcional)
-      example: Camera Sala
 
 call_preset:
   name: Chamar preset
   description: Move a câmera para o preset definido, evitando repetição desnecessária.
   fields:
-    device_id:
-      description: Device ID da câmera na Imou
-      example: 5250FACPBV99ADE
+    device:
+      description: Nome ou ID do dispositivo
+      example: Camera Sala
     preset:
       description: Nome do preset a ser chamado
       example: sala

--- a/custom_components/imou_control/services.yaml
+++ b/custom_components/imou_control/services.yaml
@@ -35,6 +35,17 @@ define_preset:
       description: Zoom (se aplicável)
       example: 0
 
+save_preset:
+  name: Salvar preset com valores atuais
+  description: Armazena um preset usando os valores atuais das entidades H e V.
+  fields:
+    device:
+      description: Nome ou ID do dispositivo
+      example: Camera Sala
+    preset:
+      description: Nome do preset
+      example: sala
+
 call_preset:
   name: Chamar preset
   description: Move a câmera para o preset definido, evitando repetição desnecessária.

--- a/custom_components/imou_control/text.py
+++ b/custom_components/imou_control/text.py
@@ -20,7 +20,7 @@ class ImouPresetText(TextEntity):
             manufacturer="Imou",
             name=data["name"],
         )
-        self._attr_has_entity_name = True
+        self._attr_has_entity_name = False
         self._attr_translation_key = "preset_name"
 
     @property

--- a/custom_components/imou_control/text.py
+++ b/custom_components/imou_control/text.py
@@ -16,9 +16,8 @@ class ImouPresetText(TextEntity):
         self._attr_mode = TextMode.TEXT
         self._attr_unique_id = f"{self._device_id}_preset_name"
         self._attr_device_info = DeviceInfo(identifiers={(DOMAIN, self._device_id)})
-        self._attr_has_entity_name = False
+        self._attr_has_entity_name = True
         self._attr_translation_key = "preset_name"
-        self._attr_translation_placeholders = {"device": data["name"]}
 
     @property
     def native_value(self) -> str | None:

--- a/custom_components/imou_control/text.py
+++ b/custom_components/imou_control/text.py
@@ -14,22 +14,15 @@ class ImouPresetText(TextEntity):
         self._data = data
         self._attr_should_poll = False
         self._attr_mode = TextMode.TEXT
-
-    @property
-    def name(self) -> str:
-        return f"{self._data['name']} Preset Name"
-
-    @property
-    def unique_id(self) -> str:
-        return f"{self._device_id}_preset_name"
+        self._attr_unique_id = f"{self._device_id}_preset_name"
+        self._attr_device_info = DeviceInfo(identifiers={(DOMAIN, self._device_id)})
+        self._attr_has_entity_name = False
+        self._attr_translation_key = "preset_name"
+        self._attr_translation_placeholders = {"device": data["name"]}
 
     @property
     def native_value(self) -> str | None:
         return self._data.get("preset_name", "")
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        return DeviceInfo(identifiers={(DOMAIN, self._device_id)})
 
     async def async_set_value(self, value: str) -> None:
         self._data["preset_name"] = value

--- a/custom_components/imou_control/text.py
+++ b/custom_components/imou_control/text.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from homeassistant.components.text import TextEntity, TextMode
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
+
+
+class ImouPresetText(TextEntity):
+    def __init__(self, hass: HomeAssistant, device_id: str, data: dict):
+        self._hass = hass
+        self._device_id = device_id
+        self._data = data
+        self._attr_should_poll = False
+        self._attr_mode = TextMode.TEXT
+
+    @property
+    def name(self) -> str:
+        return f"{self._data['name']} Preset Name"
+
+    @property
+    def unique_id(self) -> str:
+        return f"{self._device_id}_preset_name"
+
+    @property
+    def native_value(self) -> str | None:
+        return self._data.get("preset_name", "")
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        return DeviceInfo(identifiers={(DOMAIN, self._device_id)})
+
+    async def async_set_value(self, value: str) -> None:
+        self._data["preset_name"] = value
+        self.async_write_ha_state()
+
+
+async def async_setup_entry(hass: HomeAssistant, entry, async_add_entities):
+    data = hass.data[DOMAIN][entry.entry_id]
+    entities = []
+    for device_id, dev in data["devices"].items():
+        entities.append(ImouPresetText(hass, device_id, dev))
+    async_add_entities(entities)

--- a/custom_components/imou_control/text.py
+++ b/custom_components/imou_control/text.py
@@ -15,7 +15,11 @@ class ImouPresetText(TextEntity):
         self._attr_should_poll = False
         self._attr_mode = TextMode.TEXT
         self._attr_unique_id = f"{self._device_id}_preset_name"
-        self._attr_device_info = DeviceInfo(identifiers={(DOMAIN, self._device_id)})
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, self._device_id)},
+            manufacturer="Imou",
+            name=data["name"],
+        )
         self._attr_has_entity_name = True
         self._attr_translation_key = "preset_name"
 

--- a/custom_components/imou_control/translations/en.json
+++ b/custom_components/imou_control/translations/en.json
@@ -1,18 +1,18 @@
 {
   "entity": {
     "button": {
-      "move": {"name": "Move"},
-      "save_preset": {"name": "Save Preset"}
+      "move": {"name": "Imou 3 Move"},
+      "save_preset": {"name": "Imou 4 Save Preset"}
     },
     "number": {
-      "horizontal": {"name": "Horizontal"},
-      "vertical": {"name": "Vertical"}
+      "horizontal": {"name": "Imou 1 Horizontal"},
+      "vertical": {"name": "Imou 2 Vertical"}
     },
     "select": {
-      "presets": {"name": "Presets"}
+      "presets": {"name": "Imou 5 Presets"}
     },
     "text": {
-      "preset_name": {"name": "Preset Name"}
+      "preset_name": {"name": "Imou Preset Name"}
     }
   }
 }

--- a/custom_components/imou_control/translations/en.json
+++ b/custom_components/imou_control/translations/en.json
@@ -1,18 +1,18 @@
 {
   "entity": {
     "button": {
-      "move": {"name": "Imou {device} Move"},
-      "save_preset": {"name": "Imou {device} Save Preset"}
+      "move": {"name": "Move"},
+      "save_preset": {"name": "Save Preset"}
     },
     "number": {
-      "horizontal": {"name": "Imou {device} Horizontal"},
-      "vertical": {"name": "Imou {device} Vertical"}
+      "horizontal": {"name": "Horizontal"},
+      "vertical": {"name": "Vertical"}
     },
     "select": {
-      "presets": {"name": "Imou {device} Presets"}
+      "presets": {"name": "Presets"}
     },
     "text": {
-      "preset_name": {"name": "Imou {device} Preset Name"}
+      "preset_name": {"name": "Preset Name"}
     }
   }
 }

--- a/custom_components/imou_control/translations/en.json
+++ b/custom_components/imou_control/translations/en.json
@@ -1,0 +1,18 @@
+{
+  "entity": {
+    "button": {
+      "move": {"name": "Imou {device} Move"},
+      "save_preset": {"name": "Imou {device} Save Preset"}
+    },
+    "number": {
+      "horizontal": {"name": "Imou {device} Horizontal"},
+      "vertical": {"name": "Imou {device} Vertical"}
+    },
+    "select": {
+      "presets": {"name": "Imou {device} Presets"}
+    },
+    "text": {
+      "preset_name": {"name": "Imou {device} Preset Name"}
+    }
+  }
+}

--- a/custom_components/imou_control/translations/pt-BR.json
+++ b/custom_components/imou_control/translations/pt-BR.json
@@ -1,0 +1,18 @@
+{
+  "entity": {
+    "button": {
+      "move": {"name": "Imou {device} Mover"},
+      "save_preset": {"name": "Imou {device} Salvar Predefinição"}
+    },
+    "number": {
+      "horizontal": {"name": "Imou {device} Horizontal"},
+      "vertical": {"name": "Imou {device} Vertical"}
+    },
+    "select": {
+      "presets": {"name": "Imou {device} Predefinições"}
+    },
+    "text": {
+      "preset_name": {"name": "Imou {device} Nome do Preset"}
+    }
+  }
+}

--- a/custom_components/imou_control/translations/pt-BR.json
+++ b/custom_components/imou_control/translations/pt-BR.json
@@ -1,18 +1,18 @@
 {
   "entity": {
     "button": {
-      "move": {"name": "Mover"},
-      "save_preset": {"name": "Salvar Predefinição"}
+      "move": {"name": "Imou 3 Mover"},
+      "save_preset": {"name": "Imou 4 Salvar Predefinição"}
     },
     "number": {
-      "horizontal": {"name": "Horizontal"},
-      "vertical": {"name": "Vertical"}
+      "horizontal": {"name": "Imou 1 Horizontal"},
+      "vertical": {"name": "Imou 2 Vertical"}
     },
     "select": {
-      "presets": {"name": "Predefinições"}
+      "presets": {"name": "Imou 5 Predefinições"}
     },
     "text": {
-      "preset_name": {"name": "Nome do Preset"}
+      "preset_name": {"name": "Imou Nome do Preset"}
     }
   }
 }

--- a/custom_components/imou_control/translations/pt-BR.json
+++ b/custom_components/imou_control/translations/pt-BR.json
@@ -1,18 +1,18 @@
 {
   "entity": {
     "button": {
-      "move": {"name": "Imou {device} Mover"},
-      "save_preset": {"name": "Imou {device} Salvar Predefinição"}
+      "move": {"name": "Mover"},
+      "save_preset": {"name": "Salvar Predefinição"}
     },
     "number": {
-      "horizontal": {"name": "Imou {device} Horizontal"},
-      "vertical": {"name": "Imou {device} Vertical"}
+      "horizontal": {"name": "Horizontal"},
+      "vertical": {"name": "Vertical"}
     },
     "select": {
-      "presets": {"name": "Imou {device} Predefinições"}
+      "presets": {"name": "Predefinições"}
     },
     "text": {
-      "preset_name": {"name": "Imou {device} Nome do Preset"}
+      "preset_name": {"name": "Nome do Preset"}
     }
   }
 }


### PR DESCRIPTION
## Summary
- Fetch device list from Imou API and register devices automatically
- Add number entities for H and V positioning and select entity for presets
- Track preset calls via event and allow services to use device name or ID

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c731c860f88325a64544e34b745021