### PR TITLE
Update entity labels to remove numeric prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@ Para cada câmera encontrada são criadas as seguintes entidades auxiliares:
 
 | Tipo    | Identificador | Função |
 |---------|---------------|--------|
-| `number` | **Horizontal (h)** e **Vertical (v)** | Guardam os valores normalizados de -1.0 a 1.0 utilizados para mover a câmera. Eles não movimentam a câmera diretamente; utilizam-se desses valores no botão "Mover" ou nos serviços. |
-| `text`   | **Nome do preset** | Campo livre para informar o nome de um *preset* antes de pressionar o botão "Salvar preset". |
-| `button` | **Mover** | Chama a API `set_position` usando os valores atuais dos eixos `h`, `v` (e `z`, se definido). |
-| `button` | **Salvar preset** | Salva localmente um *preset* com o nome definido na entidade de texto e os valores atuais de `h`, `v` e `z`. |
-| `select` | **Presets** | Lista os *presets* salvos para a câmera. Selecionar uma opção chama automaticamente o serviço `call_preset`. |
+| `number` | **Movimento - Eixo Horizontal (h)** e **Movimento - Eixo Vertical (v)** | Guardam os valores normalizados de -1.0 a 1.0 utilizados para mover a câmera. Eles não movimentam a câmera diretamente; utilizam-se desses valores no botão "Movimento - Mover Câmera" ou nos serviços. |
+| `text`   | **Predefinição - Nome** | Campo livre para informar o nome de um *preset* antes de pressionar o botão "Predefinição - Salvar Posição da Câmera". |
+| `button` | **Movimento - Mover Câmera** | Chama a API `set_position` usando os valores atuais dos eixos `h`, `v` (e `z`, se definido). |
+| `button` | **Predefinição - Salvar Posição da Câmera** | Salva localmente um *preset* com o nome definido na entidade de texto e os valores atuais de `h`, `v` e `z`. |
+| `select` | **Predefinição - Selecionar** | Lista os *presets* salvos para a câmera. Selecionar uma opção chama automaticamente o serviço `call_preset`. |
 
 Os *presets* são persistidos em armazenamento local (`.storage`) do Home Assistant. Ao adicionar, renomear ou remover *presets*, o seletor é atualizado automaticamente.
 
@@ -57,7 +57,7 @@ Registra um *preset* informando explicitamente os valores `h`, `v` e `z`.
 ### `imou_control.save_preset`
 Salva um *preset* utilizando os valores atualmente armazenados nas entidades `number` (`h`, `v`) e `z` (quando disponível).
 
-Pode ser acionado pelo botão "Salvar preset" ou manualmente via serviço. Caso o *preset* já exista, ele é sobrescrito.
+Pode ser acionado pelo botão "Predefinição - Salvar Posição da Câmera" ou manualmente via serviço. Caso o *preset* já exista, ele é sobrescrito.
 
 ### `imou_control.call_preset`
 Move a câmera para o *preset* informado. Se o *preset* já estiver ativo, a chamada é ignorada para evitar movimentações desnecessárias.

--- a/custom_components/imou_control/translations/en.json
+++ b/custom_components/imou_control/translations/en.json
@@ -1,18 +1,18 @@
 {
   "entity": {
     "button": {
-      "move": {"name": "3 Move"},
-      "save_preset": {"name": "5 Save Preset"}
+      "move": {"name": "Movement - Move Camera"},
+      "save_preset": {"name": "Preset - Save Camera Position"}
     },
     "number": {
-      "horizontal": {"name": "1 Horizontal"},
-      "vertical": {"name": "2 Vertical"}
+      "horizontal": {"name": "Movement - Horizontal Axis"},
+      "vertical": {"name": "Movement - Vertical Axis"}
     },
     "select": {
-      "presets": {"name": "6 Presets"}
+      "presets": {"name": "Preset - Select"}
     },
     "text": {
-      "preset_name": {"name": "4 Preset Name"}
+      "preset_name": {"name": "Preset - Name"}
     }
   }
 }

--- a/custom_components/imou_control/translations/pt-BR.json
+++ b/custom_components/imou_control/translations/pt-BR.json
@@ -1,18 +1,18 @@
 {
   "entity": {
     "button": {
-      "move": {"name": "3 Mover"},
-      "save_preset": {"name": "5 Salvar Predefinição"}
+      "move": {"name": "Movimento - Mover Câmera"},
+      "save_preset": {"name": "Predefinição - Salvar Posição da Câmera"}
     },
     "number": {
-      "horizontal": {"name": "1 Horizontal"},
-      "vertical": {"name": "2 Vertical"}
+      "horizontal": {"name": "Movimento - Eixo Horizontal"},
+      "vertical": {"name": "Movimento - Eixo Vertical"}
     },
     "select": {
-      "presets": {"name": "6 Predefinições"}
+      "presets": {"name": "Predefinição - Selecionar"}
     },
     "text": {
-      "preset_name": {"name": "4 Nome da Predefinição"}
+      "preset_name": {"name": "Predefinição - Nome"}
     }
   }
 }


### PR DESCRIPTION
## Summary
- rename entity translations to group movement and preset entities without numeric prefixes
- refresh README instructions to reference the new entity labels

## Testing
- python -m json.tool custom_components/imou_control/translations/en.json
- python -m json.tool custom_components/imou_control/translations/pt-BR.json

------
https://chatgpt.com/codex/tasks/task_e_68c9cf38cb8c8325b32b9fd35be75c30