### PR TITLE
Add API usage tracker sensor

### DIFF
--- a/custom_components/imou_control/manifest.json
+++ b/custom_components/imou_control/manifest.json
@@ -6,5 +6,5 @@
   "requirements": ["requests>=2.28.0"],
   "codeowners": ["@you"],
   "iot_class": "cloud_polling",
-  "platforms": ["number", "select", "button", "text"]
+  "platforms": ["number", "select", "button", "text", "sensor"]
 }

--- a/custom_components/imou_control/sensor.py
+++ b/custom_components/imou_control/sensor.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Callable
+
+from homeassistant.components.sensor import SensorEntity, SensorStateClass
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import DeviceInfo
+
+from .const import DOMAIN
+from .usage import ApiUsageTracker
+
+
+@dataclass
+class _UsageData:
+    tracker: ApiUsageTracker
+    entry_id: str
+
+
+class ImouApiUsageSensor(SensorEntity):
+    _attr_has_entity_name = True
+    _attr_translation_key = "api_usage"
+    _attr_icon = "mdi:counter"
+    _attr_native_unit_of_measurement = None
+    _attr_state_class = SensorStateClass.MEASUREMENT
+
+    def __init__(self, data: _UsageData) -> None:
+        self._tracker = data.tracker
+        self._entry_id = data.entry_id
+        self._remove_listener: Callable[[], None] | None = None
+        self._attr_unique_id = f"{self._entry_id}_api_usage"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, f"account_{self._entry_id}")},
+            manufacturer="Imou",
+            name="Imou Account",
+        )
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        self._remove_listener = self._tracker.async_add_listener(self.async_write_ha_state)
+        self.async_write_ha_state()
+
+    async def async_will_remove_from_hass(self) -> None:
+        if self._remove_listener is not None:
+            self._remove_listener()
+            self._remove_listener = None
+        await super().async_will_remove_from_hass()
+
+    @property
+    def native_value(self) -> int:
+        return self._tracker.count
+
+    @property
+    def extra_state_attributes(self) -> dict[str, str | None]:
+        attrs: dict[str, str | None] = {}
+        period = self._tracker.period
+        if period is not None:
+            attrs["period"] = period
+
+        last_reset = self._tracker.last_reset
+        if last_reset:
+            attrs["last_reset"] = self._format_dt(last_reset)
+
+        last_call = self._tracker.last_call
+        if last_call:
+            attrs["last_call"] = self._format_dt(last_call)
+
+        return attrs
+
+    @staticmethod
+    def _format_dt(value: datetime) -> str:
+        return value.isoformat()
+
+
+async def async_setup_entry(hass: HomeAssistant, entry, async_add_entities) -> None:
+    data = hass.data[DOMAIN][entry.entry_id]
+    tracker: ApiUsageTracker = data["usage"]
+    async_add_entities([ImouApiUsageSensor(_UsageData(tracker, entry.entry_id))])

--- a/custom_components/imou_control/translations/en.json
+++ b/custom_components/imou_control/translations/en.json
@@ -13,6 +13,9 @@
     },
     "text": {
       "preset_name": {"name": "Preset - Name"}
+    },
+    "sensor": {
+      "api_usage": {"name": "Account - API Usage"}
     }
   }
 }

--- a/custom_components/imou_control/translations/pt-BR.json
+++ b/custom_components/imou_control/translations/pt-BR.json
@@ -13,6 +13,9 @@
     },
     "text": {
       "preset_name": {"name": "Predefinição - Nome"}
+    },
+    "sensor": {
+      "api_usage": {"name": "Conta - Uso da API"}
     }
   }
 }

--- a/custom_components/imou_control/usage.py
+++ b/custom_components/imou_control/usage.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
+from typing import Any
+
+from homeassistant.helpers.storage import Store
+
+
+class ApiUsageTracker:
+    """Track monthly API usage based on timestamps returned by Imou."""
+
+    def __init__(self, store: Store, *, save_delay: float = 30.0) -> None:
+        self._store = store
+        self._save_delay = save_delay
+        self._period: str | None = None
+        self._count: int = 0
+        self._last_reset: datetime | None = None
+        self._last_call: datetime | None = None
+        self._listeners: set[Callable[[], None]] = set()
+
+    async def async_load(self) -> None:
+        """Load persisted usage data from storage."""
+
+        data = await self._store.async_load()
+        if not data:
+            return
+
+        self._period = data.get("period")
+        self._count = int(data.get("count", 0))
+
+        last_reset = data.get("last_reset")
+        if last_reset:
+            self._last_reset = self._parse_iso_datetime(last_reset)
+
+        last_call = data.get("last_call")
+        if last_call:
+            self._last_call = self._parse_iso_datetime(last_call)
+
+    @property
+    def count(self) -> int:
+        """Return the number of API calls performed in the current period."""
+
+        return self._count
+
+    @property
+    def period(self) -> str | None:
+        """Return the identifier of the current period (YYYY-MM)."""
+
+        return self._period
+
+    @property
+    def last_reset(self) -> datetime | None:
+        """Return when the counter was last reset."""
+
+        return self._last_reset
+
+    @property
+    def last_call(self) -> datetime | None:
+        """Return when the last API call was observed."""
+
+        return self._last_call
+
+    def note_call(self, date_header: str | None = None) -> None:
+        """Record a single API call using the server-provided timestamp."""
+
+        moment = self._parse_date_header(date_header)
+        period = self._period_key(moment)
+
+        if self._period != period:
+            self._period = period
+            self._count = 0
+            self._last_reset = moment
+
+        self._count += 1
+        self._last_call = moment
+        self._store.async_delay_save(self._as_dict, self._save_delay)
+        self._notify_listeners()
+
+    def async_add_listener(self, listener: Callable[[], None]) -> Callable[[], None]:
+        """Register a callback invoked whenever usage changes."""
+
+        self._listeners.add(listener)
+
+        def _remove() -> None:
+            self._listeners.discard(listener)
+
+        return _remove
+
+    def _notify_listeners(self) -> None:
+        for listener in list(self._listeners):
+            listener()
+
+    def _as_dict(self) -> dict[str, Any]:
+        return {
+            "period": self._period,
+            "count": self._count,
+            "last_reset": self._format_datetime(self._last_reset),
+            "last_call": self._format_datetime(self._last_call),
+        }
+
+    @staticmethod
+    def _period_key(moment: datetime) -> str:
+        return f"{moment.year:04d}-{moment.month:02d}"
+
+    @staticmethod
+    def _parse_iso_datetime(value: str) -> datetime:
+        dt = datetime.fromisoformat(value)
+        if dt.tzinfo is None:
+            return dt.replace(tzinfo=timezone.utc)
+        return dt.astimezone(timezone.utc)
+
+    @staticmethod
+    def _format_datetime(value: datetime | None) -> str | None:
+        if value is None:
+            return None
+        return value.astimezone(timezone.utc).isoformat()
+
+    @staticmethod
+    def _parse_date_header(value: str | None) -> datetime:
+        if value:
+            try:
+                parsed = parsedate_to_datetime(value)
+            except (TypeError, ValueError, IndexError):
+                parsed = None
+            if parsed is not None:
+                if parsed.tzinfo is None:
+                    return parsed.replace(tzinfo=timezone.utc)
+                return parsed.astimezone(timezone.utc)
+
+        return datetime.now(timezone.utc)
+


### PR DESCRIPTION
## Summary
- add a persistent ApiUsageTracker that records API calls using the server-provided timestamp and resets each month
- hook the tracker into token and command calls and expose the data through a new sensor entity
- update translations and the manifest so Home Assistant shows a monthly API usage indicator for each account

## Testing
- python -m compileall custom_components/imou_control

------
https://chatgpt.com/codex/tasks/task_e_68c8738bd7b88325900f18d501cd3718