### PR TITLE
Add pytest tests for token manager and API client

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,3 @@
+pytest>=7.0
+pytest-asyncio>=0.20
+aiohttp>=3.9

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import sys
+import types
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parent.parent
+PACKAGE_NAME = "custom_components"
+COMPONENT_NAME = "imou_control"
+PACKAGE_PATH = ROOT / PACKAGE_NAME / COMPONENT_NAME
+
+
+def _ensure_namespace_package() -> None:
+    if PACKAGE_NAME not in sys.modules:
+        namespace = types.ModuleType(PACKAGE_NAME)
+        namespace.__path__ = [str(ROOT / PACKAGE_NAME)]  # type: ignore[attr-defined]
+        sys.modules[PACKAGE_NAME] = namespace
+
+    full_package = f"{PACKAGE_NAME}.{COMPONENT_NAME}"
+    if full_package not in sys.modules:
+        package = types.ModuleType(full_package)
+        package.__path__ = [str(PACKAGE_PATH)]  # type: ignore[attr-defined]
+        sys.modules[full_package] = package
+
+
+def _ensure_usage_stub() -> None:
+    usage_name = f"{PACKAGE_NAME}.{COMPONENT_NAME}.usage"
+    if usage_name in sys.modules:
+        return
+
+    module = types.ModuleType(usage_name)
+
+    class ApiUsageTracker:  # pragma: no cover - simple stub
+        def __init__(self, *_args: Any, **_kwargs: Any) -> None:
+            pass
+
+        def note_call(self, *_args: Any, **_kwargs: Any) -> None:
+            pass
+
+        async def async_load(self) -> None:
+            return None
+
+    module.ApiUsageTracker = ApiUsageTracker  # type: ignore[attr-defined]
+    sys.modules[usage_name] = module
+
+
+def load_imou_module(module: str):
+    _ensure_namespace_package()
+    _ensure_usage_stub()
+    full_name = f"{PACKAGE_NAME}.{COMPONENT_NAME}.{module}"
+    module_path = PACKAGE_PATH / f"{module}.py"
+    spec = spec_from_file_location(full_name, module_path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Unable to load module {full_name} from {module_path}")
+    loaded = module_from_spec(spec)
+    sys.modules[full_name] = loaded
+    spec.loader.exec_module(loaded)
+    return loaded

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -1,0 +1,51 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from tests.helpers import load_imou_module
+
+ApiClient = load_imou_module("api").ApiClient
+
+
+@pytest.mark.asyncio
+async def test_call_with_retry_refreshes_token_on_tk1002(monkeypatch):
+    session = MagicMock()
+    token_getter = AsyncMock(return_value="cached-token")
+    token_refresher = AsyncMock(return_value="refreshed-token")
+
+    client = ApiClient(
+        app_id="app",
+        app_secret="secret",
+        base_url="https://example.com",
+        session=session,
+        token_getter=token_getter,
+        token_refresher=token_refresher,
+    )
+
+    calls = []
+    responses = [
+        {"result": {"code": "TK1002", "msg": "token expired"}},
+        {"result": {"code": "0", "msg": "ok", "data": {"value": 1}}},
+    ]
+
+    async def fake_do_call(path, params, include_token=True, token_override=None):
+        call_index = len(calls)
+        calls.append(
+            {
+                "path": path,
+                "params": dict(params),
+                "include_token": include_token,
+                "token_override": token_override,
+            }
+        )
+        return responses[call_index]
+
+    monkeypatch.setattr(client, "_do_call", fake_do_call)
+
+    result = await client._call_with_retry("/test", {"foo": "bar"}, include_token=True)
+
+    assert result == responses[1]
+    assert len(calls) == 2
+    assert calls[0]["token_override"] is None
+    assert calls[1]["token_override"] == "refreshed-token"
+    assert token_refresher.await_count == 1

--- a/tests/test_token_manager.py
+++ b/tests/test_token_manager.py
@@ -1,0 +1,77 @@
+import time
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from tests.helpers import load_imou_module
+
+TokenManager = load_imou_module("token_manager").TokenManager
+
+
+@pytest.mark.asyncio
+async def test_get_token_returns_cached_value(monkeypatch):
+    manager = TokenManager(
+        app_id="app",
+        app_secret="secret",
+        base_url="https://example.com",
+        session=MagicMock(),
+    )
+
+    manager._token = "cached-token"
+    manager._exp_ts = time.time() + 60
+
+    fetch_mock = AsyncMock()
+    monkeypatch.setattr(manager, "_fetch_new_token", fetch_mock)
+
+    token = await manager.get_token()
+
+    assert token == "cached-token"
+    fetch_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_token_refreshes_when_expired(monkeypatch):
+    manager = TokenManager(
+        app_id="app",
+        app_secret="secret",
+        base_url="https://example.com",
+        session=MagicMock(),
+    )
+
+    manager._token = "old-token"
+    manager._exp_ts = time.time() - 1
+
+    new_expiration = time.time() + 120
+    fetch_mock = AsyncMock(return_value=("new-token", new_expiration))
+    monkeypatch.setattr(manager, "_fetch_new_token", fetch_mock)
+
+    token = await manager.get_token()
+
+    assert token == "new-token"
+    assert manager._token == "new-token"
+    assert manager._exp_ts == new_expiration
+    assert fetch_mock.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_refresh_token_forces_new_token(monkeypatch):
+    manager = TokenManager(
+        app_id="app",
+        app_secret="secret",
+        base_url="https://example.com",
+        session=MagicMock(),
+    )
+
+    manager._token = "valid-token"
+    manager._exp_ts = time.time() + 120
+
+    forced_expiration = time.time() + 300
+    fetch_mock = AsyncMock(return_value=("forced-token", forced_expiration))
+    monkeypatch.setattr(manager, "_fetch_new_token", fetch_mock)
+
+    token = await manager.refresh_token()
+
+    assert token == "forced-token"
+    assert manager._token == "forced-token"
+    assert manager._exp_ts == forced_expiration
+    assert fetch_mock.await_count == 1


### PR DESCRIPTION
## Summary
- add pytest dependencies for test execution and aiohttp import support
- provide a helper loader to import integration modules without Home Assistant
- add unit tests covering token refresh/invalidation and retry logic on TK1002

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9dae349808325b2b45eaf45bcb223