### PR TITLE
Add delete preset service

### DIFF
--- a/custom_components/imou_control/services.yaml
+++ b/custom_components/imou_control/services.yaml
@@ -56,3 +56,14 @@ call_preset:
     preset:
       description: Nome do preset a ser chamado
       example: sala
+
+delete_preset:
+  name: Remover preset
+  description: Remove um preset armazenado localmente para o dispositivo.
+  fields:
+    device:
+      description: Nome ou ID do dispositivo
+      example: Camera Sala
+    preset:
+      description: Nome do preset a ser removido
+      example: sala


### PR DESCRIPTION
## Summary
- add the delete_preset service definition to the integration manifest
- implement the Home Assistant service handler to drop presets and refresh selectors

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9ddbe8a1c8325a8d61adee849b5c2