### PR TITLE
Release 1.0.1: sync numeric controls with presets

### DIFF
--- a/custom_components/imou_control/manifest.json
+++ b/custom_components/imou_control/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "imou_control",
   "name": "Imou Control",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "config_flow": true,
   "requirements": ["requests>=2.28.0"],
   "codeowners": ["@you"],

--- a/custom_components/imou_control/number.py
+++ b/custom_components/imou_control/number.py
@@ -34,10 +34,18 @@ class ImouAxisNumber(NumberEntity):
         self._attr_native_value = float(value)
         self.async_write_ha_state()
 
+    def update_from_preset(self, value: float) -> None:
+        self._attr_native_value = float(value)
+        self.async_write_ha_state()
+
 async def async_setup_entry(hass: HomeAssistant, entry, async_add_entities):
     data = hass.data[DOMAIN][entry.entry_id]
     entities = []
     for device_id, dev in data["devices"].items():
-        entities.append(ImouAxisNumber(hass, device_id, "h", dev))
-        entities.append(ImouAxisNumber(hass, device_id, "v", dev))
+        number_h = ImouAxisNumber(hass, device_id, "h", dev)
+        number_v = ImouAxisNumber(hass, device_id, "v", dev)
+        dev["number_entities"]["h"] = number_h
+        dev["number_entities"]["v"] = number_v
+        entities.append(number_h)
+        entities.append(number_v)
     async_add_entities(entities)


### PR DESCRIPTION
## Summary
- store references to numeric axis entities for each device
- update preset selection to push horizontal and vertical coordinates into the number controls
- bump the integration version metadata to 1.0.1

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9df5bf89c8325ab81ad8d08860559