### PR TITLE
Expose integration version in device info

### DIFF
--- a/custom_components/imou_control/__init__.py
+++ b/custom_components/imou_control/__init__.py
@@ -14,6 +14,7 @@ from .const import (
     CONF_APP_SECRET,
     CONF_URL_BASE,
     EVENT_PRESET_CALLED,
+    INTEGRATION_VERSION,
 )
 from .token_manager import TokenManager
 from .api import ApiClient
@@ -84,6 +85,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             identifiers={(DOMAIN, device_id)},
             manufacturer="Imou",
             name=name,
+            sw_version=INTEGRATION_VERSION,
         )
 
     async def _save_presets() -> None:

--- a/custom_components/imou_control/button.py
+++ b/custom_components/imou_control/button.py
@@ -4,7 +4,7 @@ from homeassistant.components.button import ButtonEntity
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.core import HomeAssistant
 
-from .const import DOMAIN
+from .const import DOMAIN, INTEGRATION_VERSION
 
 
 class ImouMoveButton(ButtonEntity):
@@ -19,6 +19,7 @@ class ImouMoveButton(ButtonEntity):
             identifiers={(DOMAIN, self._device_id)},
             manufacturer="Imou",
             name=data["name"],
+            sw_version=INTEGRATION_VERSION,
         )
         self._attr_has_entity_name = True
         self._attr_translation_key = "move"
@@ -43,6 +44,7 @@ class ImouSavePresetButton(ButtonEntity):
             identifiers={(DOMAIN, self._device_id)},
             manufacturer="Imou",
             name=data["name"],
+            sw_version=INTEGRATION_VERSION,
         )
         self._attr_has_entity_name = True
         self._attr_translation_key = "save_preset"

--- a/custom_components/imou_control/const.py
+++ b/custom_components/imou_control/const.py
@@ -1,4 +1,5 @@
 DOMAIN = "imou_control"
+INTEGRATION_VERSION = "1.1.0"
 
 # Credenciais configuradas no config_flow
 CONF_APP_ID = "app_id"

--- a/custom_components/imou_control/manifest.json
+++ b/custom_components/imou_control/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "imou_control",
   "name": "Imou Control",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "config_flow": true,
   "requirements": ["requests>=2.28.0"],
   "codeowners": ["@you"],

--- a/custom_components/imou_control/number.py
+++ b/custom_components/imou_control/number.py
@@ -4,7 +4,7 @@ from homeassistant.components.number import NumberEntity, NumberMode
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.core import HomeAssistant
 
-from .const import DOMAIN
+from .const import DOMAIN, INTEGRATION_VERSION
 
 class ImouAxisNumber(NumberEntity):
     def __init__(self, hass: HomeAssistant, device_id: str, axis: str, data: dict):
@@ -19,6 +19,7 @@ class ImouAxisNumber(NumberEntity):
             identifiers={(DOMAIN, device_id)},
             manufacturer="Imou",
             name=data["name"],
+            sw_version=INTEGRATION_VERSION,
         )
         self._attr_has_entity_name = True
         key = "horizontal" if axis == "h" else "vertical"

--- a/custom_components/imou_control/select.py
+++ b/custom_components/imou_control/select.py
@@ -4,7 +4,7 @@ from homeassistant.components.select import SelectEntity
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.core import HomeAssistant
 
-from .const import DOMAIN
+from .const import DOMAIN, INTEGRATION_VERSION
 
 class ImouPresetSelect(SelectEntity):
     def __init__(self, hass: HomeAssistant, api, device_id: str, data: dict):
@@ -19,6 +19,7 @@ class ImouPresetSelect(SelectEntity):
             identifiers={(DOMAIN, self._device_id)},
             manufacturer="Imou",
             name=data["name"],
+            sw_version=INTEGRATION_VERSION,
         )
         self._attr_has_entity_name = True
         self._attr_translation_key = "presets"

--- a/custom_components/imou_control/sensor.py
+++ b/custom_components/imou_control/sensor.py
@@ -8,7 +8,7 @@ from homeassistant.components.sensor import SensorEntity, SensorStateClass
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo
 
-from .const import DOMAIN
+from .const import DOMAIN, INTEGRATION_VERSION
 from .usage import ApiUsageTracker
 
 
@@ -34,6 +34,7 @@ class ImouApiUsageSensor(SensorEntity):
             identifiers={(DOMAIN, f"account_{self._entry_id}")},
             manufacturer="Imou",
             name="Imou Account",
+            sw_version=INTEGRATION_VERSION,
         )
 
     async def async_added_to_hass(self) -> None:

--- a/custom_components/imou_control/text.py
+++ b/custom_components/imou_control/text.py
@@ -4,7 +4,7 @@ from homeassistant.components.text import TextEntity, TextMode
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.core import HomeAssistant
 
-from .const import DOMAIN
+from .const import DOMAIN, INTEGRATION_VERSION
 
 
 class ImouPresetText(TextEntity):
@@ -19,6 +19,7 @@ class ImouPresetText(TextEntity):
             identifiers={(DOMAIN, self._device_id)},
             manufacturer="Imou",
             name=data["name"],
+            sw_version=INTEGRATION_VERSION,
         )
         self._attr_has_entity_name = True
         self._attr_translation_key = "preset_name"


### PR DESCRIPTION
## Summary
- bump the integration manifest to version 1.1.0
- expose the integration version constant and attach it to all DeviceInfo definitions
- register the integration version in the device registry so Home Assistant shows it on the device card

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'aiohttp')*

------
https://chatgpt.com/codex/tasks/task_e_690022c763ec8325b9882e6412cb2a26