### PR TITLE
imou_control: add debug logging and warning for device discovery and API responses

### DIFF
--- a/custom_components/imou_control/__init__.py
+++ b/custom_components/imou_control/__init__.py
@@ -30,6 +30,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     app_secret = entry.data[CONF_APP_SECRET]
     url_base   = entry.data[CONF_URL_BASE]
 
+    _LOGGER.debug("Iniciando setup da entrada %s do imou_control", entry.entry_id)
     session = async_get_clientsession(hass)
 
     usage_store = Store(hass, 1, f"{DOMAIN}_usage_{entry.entry_id}")
@@ -61,14 +62,32 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     registry = dr.async_get(hass)
     try:
+        _LOGGER.debug("Buscando dispositivos Imou para a entrada %s", entry.entry_id)
         devices_info = await api.list_devices()
     except Exception as err:
         _LOGGER.error("Não foi possível obter a lista de dispositivos: %s", err)
         devices_info = []
+    _LOGGER.debug(
+        "Descoberta de dispositivos concluída para %s: %d dispositivos",
+        entry.entry_id,
+        len(devices_info),
+    )
+
+    if not devices_info:
+        _LOGGER.warning(
+            "Nenhum dispositivo retornado pela API da Imou para a entrada %s. "
+            "Verifique app_id/app_secret/url_base e se a conta possui câmeras vinculadas.",
+            entry.entry_id,
+        )
     for info in devices_info:
         device_id = info.get("deviceId")
         raw_name = info.get("deviceName") or device_id
         name = f"Imou {raw_name}"
+        _LOGGER.debug(
+            "Registrando dispositivo descoberto: device_id=%s, nome=%s",
+            device_id,
+            raw_name,
+        )
         data_entry["devices"][device_id] = {
             "name": name,
             "presets": saved.get(device_id, {}),

--- a/custom_components/imou_control/api.py
+++ b/custom_components/imou_control/api.py
@@ -120,6 +120,12 @@ class ApiClient:
         data = await self._do_call(path, params, include_token=include_token)
         result = data.get("result") or {}
         code = str(result.get("code", "0"))
+        _LOGGER.debug(
+            "Resposta da API em %s: code=%s, msg=%s",
+            path,
+            code,
+            result.get("msg"),
+        )
         if code == "0" or not include_token:
             return data
 
@@ -180,6 +186,12 @@ class ApiClient:
             or result.get("devices")
             or result.get("list")
             or []
+        )
+        _LOGGER.debug(
+            "list_devices: code=%s, msg=%s, quantidade=%d",
+            result.get("code"),
+            result.get("msg"),
+            len(devices) if isinstance(devices, list) else 0,
         )
 
         return devices if isinstance(devices, list) else []


### PR DESCRIPTION
### Motivation
- Improve observability of the Imou integration during setup and API interactions to make troubleshooting easier.
- Surface a clear warning when the Imou API returns no devices so configuration issues (credentials / account binding) are easier to detect.

### Description
- Added debug logging in `async_setup_entry` to mark start of entry setup and to log device discovery start, per-device registration, and discovery completion with device counts.
- Emit a warning when `list_devices` returns no devices to advise checking `app_id`/`app_secret`/`url_base` and account bindings.
- Added debug logging in `ApiClient._call_with_retry` to show API response `code` and `msg`, and in `ApiClient.list_devices` to log the returned `code`, `msg`, and number of devices.

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cdfad8f948325994ece7bb552b671)