### PR TITLE
Use `deviceBaseList` endpoint for device listing

### DIFF
--- a/custom_components/imou_control/const.py
+++ b/custom_components/imou_control/const.py
@@ -9,7 +9,7 @@ CONF_URL_BASE = "url_base"
 # Endpoints padrão da Open API (relativos ao url_base)
 TOKEN_ENDPOINT = "/openapi/accessToken"
 PTZ_LOCATION_ENDPOINT = "/openapi/controlLocationPTZ"
-DEVICE_LIST_ENDPOINT = "/openapi/deviceOpenList"
+DEVICE_LIST_ENDPOINT = "/openapi/deviceBaseList"
 
 # Nome do evento disparado quando um preset é chamado
 EVENT_PRESET_CALLED = "imou_control_preset_called"


### PR DESCRIPTION
### Motivation
- Atualizar o endpoint usado para listar dispositivos para refletir a mudança da API de `"/openapi/deviceOpenList"` para `"/openapi/deviceBaseList"`.

### Description
- Alterado o valor da constante `DEVICE_LIST_ENDPOINT` em `custom_components/imou_control/const.py` para `"/openapi/deviceBaseList"`.

### Testing
- Nenhum teste automatizado foi executado para esta alteração; a mudança foi validada localmente por revisão do diff e commit do arquivo.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d0772985483259f7d425721725778)