### PR TITLE
Add PTZ debug logging and call async set_position directly from button

### DIFF
--- a/custom_components/imou_control/api.py
+++ b/custom_components/imou_control/api.py
@@ -163,6 +163,18 @@ class ApiClient:
             "z": float(z),
         }
         data = await self._call_with_retry(PTZ_LOCATION_ENDPOINT, params, include_token=True)
+        result = data.get("result") or {}
+        _LOGGER.debug(
+            "Retorno controlLocationPTZ para %s: %s",
+            device_id,
+            {
+                "result": {
+                    "msg": result.get("msg"),
+                    "code": result.get("code"),
+                },
+                "id": data.get("id"),
+            },
+        )
         # sucesso já garantido por _call_with_retry (code == "0")
         return True
 

--- a/custom_components/imou_control/button.py
+++ b/custom_components/imou_control/button.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
+import logging
+
 from homeassistant.components.button import ButtonEntity
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.core import HomeAssistant
 
 from .const import DOMAIN, INTEGRATION_VERSION
+
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class ImouMoveButton(ButtonEntity):
@@ -28,8 +33,22 @@ class ImouMoveButton(ButtonEntity):
         h = self._data["coords"]["h"]
         v = self._data["coords"]["v"]
         z = self._data["coords"].get("z", 0.0)
-        await self._hass.async_add_executor_job(
-            self._api.set_position, self._device_id, h, v, z
+
+        _LOGGER.debug(
+            "Solicitando movimentação PTZ para %s (horizontal=%.2f, vertical=%.2f, zoom=%.2f)",
+            self._device_id,
+            h,
+            v,
+            z,
+        )
+
+        await self._api.set_position(self._device_id, h, v, z)
+
+        _LOGGER.debug(
+            "Movimentação PTZ solicitada com sucesso para %s (horizontal=%.2f, vertical=%.2f)",
+            self._device_id,
+            h,
+            v,
         )
 
 


### PR DESCRIPTION
### Motivation
- Improve observability of PTZ control calls by logging API result code, message and request id for easier troubleshooting of retries like TK1002.
- Remove the unnecessary use of `hass.async_add_executor_job` for `set_position` since `set_position` is asynchronous, to avoid improper scheduling and simplify the call path.
- Provide debug traces around button-triggered PTZ actions to make it clearer when moves are requested and completed.

### Description
- In `api.py` `ApiClient.set_position` now extracts `result` from the API response and logs a compact debug object containing `msg`, `code`, and `id` returned by the `controlLocationPTZ` endpoint.
- In `button.py` added `import logging` and a `_LOGGER` instance, added debug logs before and after requesting PTZ movement, and replaced `hass.async_add_executor_job(self._api.set_position, ...)` with a direct `await self._api.set_position(...)` call.
- No functional change to success handling: `set_position` still returns `True` on successful API response.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d0bd932848325b0727dbc1c0a19fc)